### PR TITLE
Add Pre-Proposal Triage Phase 1: bid package ingestion + ETG knowledge layer

### DIFF
--- a/app.py
+++ b/app.py
@@ -55,10 +55,13 @@ from config.settings import (
 from document_parser import parse_document
 from models import (
     ActivityLog,
+    BidPackage,
     ClarificationItem,
     CompanyStandard,
+    DocumentAnalysis,
     DocumentTag,
     EquipmentItem,
+    EtgKnowledgeAsset,
     Notification,
     Project,
     ProjectDocument,
@@ -77,6 +80,7 @@ from models import (
     RevisionTemplate,
     StaffRole,
     TravelExpenseRate,
+    TriageJob,
     User,
     UserRateSheet,
     UserVerticalTemplate,
@@ -262,7 +266,29 @@ with app.app_context():
                 _cur.execute('ALTER TABLE proposal_questions ADD COLUMN resolution_path VARCHAR(20) DEFAULT "internal"')
                 _conn.commit()
 
+            # Pre-Proposal Triage (Phase 1) — add new columns to project_documents
+            _cur.execute("PRAGMA table_info(project_documents)")
+            _pd_cols = {row[1] for row in _cur.fetchall()}
+            _triage_doc_migrations = [
+                ("bid_package_id", 'ALTER TABLE project_documents ADD COLUMN bid_package_id VARCHAR(32) DEFAULT NULL'),
+                ("relative_path", 'ALTER TABLE project_documents ADD COLUMN relative_path VARCHAR(1000) DEFAULT ""'),
+                ("sha256", 'ALTER TABLE project_documents ADD COLUMN sha256 VARCHAR(64) DEFAULT ""'),
+            ]
+            for _col, _sql in _triage_doc_migrations:
+                if _col not in _pd_cols:
+                    _cur.execute(_sql)
+            _conn.commit()
+
             _conn.close()
+
+            # Seed ETG knowledge base (system rows + migrate CompanyStandard).
+            from etg_knowledge_seed import migrate_company_standards, seed_system_assets
+            try:
+                seed_system_assets()
+                migrate_company_standards()
+            except Exception:
+                # Seeding failures must not crash the app boot.
+                db.session.rollback()
         finally:
             _fcntl.flock(_lock_fh, _fcntl.LOCK_UN)
 
@@ -321,6 +347,47 @@ def _can_access_project(project) -> bool:
         or project.assigned_to == current_user.id
         or current_user.is_admin
     )
+
+
+def _company_standards_data(user_id: str):
+    """Return the standards payload the proposal generator expects.
+
+    Reads from EtgKnowledgeAsset (the new structured knowledge base). The
+    legacy CompanyStandard CRUD routes mirror their writes here, so this is
+    the single read path.
+    """
+    sections = (
+        "company_profile",
+        "capabilities",
+        "tech_stack",
+        "sow_boilerplate",
+        "exclusions",
+        "pricing_reference",
+        "past_proposal",
+    )
+    from sqlalchemy import or_ as _or
+    assets = EtgKnowledgeAsset.query.filter(
+        EtgKnowledgeAsset.is_active.is_(True),
+        EtgKnowledgeAsset.section.in_(sections),
+        _or(
+            EtgKnowledgeAsset.user_id == user_id,
+            EtgKnowledgeAsset.user_id.is_(None),
+        ),
+    ).order_by(
+        EtgKnowledgeAsset.section.asc(),
+        EtgKnowledgeAsset.sort_order.asc(),
+        EtgKnowledgeAsset.title.asc(),
+    ).all()
+    if not assets:
+        return None
+    return [
+        {
+            "category": a.section.replace("_", " ").title(),
+            "title": a.title,
+            "content": a.content_md or "",
+        }
+        for a in assets
+    ]
 
 
 def _save_upload(file, subdir: str = "") -> tuple[str, str, int]:
@@ -1423,14 +1490,8 @@ def project_generate(project_id):
             for c in past_corrections
         ]
 
-    # Load company standards for auto-injection
-    standards = CompanyStandard.query.filter_by(user_id=current_user.id, is_active=True).all()
-    company_standards_data = None
-    if standards:
-        company_standards_data = [
-            {"category": s.category, "title": s.title, "content": s.content}
-            for s in standards
-        ]
+    # Load company standards for auto-injection (sourced from the ETG knowledge base).
+    company_standards_data = _company_standards_data(current_user.id)
 
     try:
         result = generate_proposal(
@@ -1724,6 +1785,261 @@ def update_close_details(project_id):
     _log_activity("close_details_update", f"Close details updated ({project.status})", project_id)
     flash("Close details saved.", "success")
     return redirect(request.referrer or url_for("reports"))
+
+
+# ---------------------------------------------------------------------------
+# Pre-Proposal Triage (Phase 1): Bid Package Ingestion & Index
+# ---------------------------------------------------------------------------
+
+BID_PACKAGE_ZIP_EXTENSIONS = {"zip"}
+
+
+@app.route("/projects/<project_id>/bid-package", methods=["GET"])
+@login_required
+def bid_package_landing(project_id):
+    """Bid package overview for a project: upload form + list of packages."""
+    project = db.session.get(Project, project_id)
+    if not _can_access_project(project):
+        abort(404)
+
+    packages = (
+        BidPackage.query.filter_by(project_id=project_id)
+        .order_by(BidPackage.ingested_at.desc())
+        .all()
+    )
+    return render_template(
+        "bid_package_landing.html",
+        project=project,
+        packages=packages,
+    )
+
+
+@app.route("/projects/<project_id>/bid-package/upload", methods=["POST"])
+@login_required
+def bid_package_upload(project_id):
+    """Accept a zip archive of bid documents and ingest it synchronously.
+
+    Synchronous because most packages fit within the gunicorn timeout. The
+    triage worker handles the per-document analysis afterward.
+    """
+    project = db.session.get(Project, project_id)
+    if not _can_access_project(project):
+        abort(404)
+
+    file = request.files.get("bid_package_zip")
+    if not file or not file.filename:
+        flash("Please choose a zip file to upload.", "error")
+        return redirect(url_for("bid_package_landing", project_id=project_id))
+
+    if not _allowed_file(file.filename, BID_PACKAGE_ZIP_EXTENSIONS):
+        flash("Bid packages must be uploaded as a .zip file.", "error")
+        return redirect(url_for("bid_package_landing", project_id=project_id))
+
+    from bid_package_service import BidPackageError, ingest_zip_filelike
+
+    try:
+        package = ingest_zip_filelike(
+            project_id=project_id,
+            user_id=current_user.id,
+            file_storage=file,
+            original_filename=secure_filename(file.filename),
+        )
+    except BidPackageError as exc:
+        flash(f"Bid package upload rejected: {exc}", "error")
+        return redirect(url_for("bid_package_landing", project_id=project_id))
+    except Exception as exc:
+        flash(f"Bid package upload failed: {exc}", "error")
+        return redirect(url_for("bid_package_landing", project_id=project_id))
+
+    _log_activity(
+        "bid_package_upload",
+        f"Ingested {package.file_count} files ({package.duplicate_count} duplicates)",
+        project_id,
+    )
+    flash(
+        f"Bid package uploaded: {package.file_count} documents accepted, "
+        f"{package.duplicate_count} duplicates skipped.",
+        "success",
+    )
+    return redirect(url_for("bid_package_index", project_id=project_id, package_id=package.id))
+
+
+@app.route("/projects/<project_id>/bid-package/<package_id>", methods=["GET"])
+@login_required
+def bid_package_index(project_id, package_id):
+    """Per-document index for a single bid package: the triage table."""
+    project = db.session.get(Project, project_id)
+    if not _can_access_project(project):
+        abort(404)
+    package = db.session.get(BidPackage, package_id)
+    if not package or package.project_id != project_id:
+        abort(404)
+
+    documents = (
+        ProjectDocument.query.filter_by(bid_package_id=package_id)
+        .order_by(ProjectDocument.relative_path.asc())
+        .all()
+    )
+
+    # Aggregate counts and build per-doc rows including analysis status.
+    rows = []
+    trade_counts: dict[str, int] = {}
+    type_counts: dict[str, int] = {}
+    for doc in documents:
+        analysis = doc.analysis
+        rows.append({
+            "id": doc.id,
+            "name": doc.original_filename,
+            "relative_path": doc.relative_path or doc.original_filename,
+            "file_size": doc.file_size,
+            "trade": (analysis.trade if analysis else "") or "",
+            "document_type": (analysis.document_type_detected if analysis else "") or "",
+            "addendum_label": (analysis.addendum_label if analysis else "") or "",
+            "synopsis": (analysis.synopsis if analysis else "") or "",
+            "needs_ocr": bool(analysis.needs_ocr) if analysis else False,
+            "status": (analysis.status if analysis else "pending"),
+            "reviewer_status": (analysis.reviewer_status if analysis else "unreviewed"),
+            "confidence": float(analysis.confidence) if analysis else 0.0,
+        })
+        if analysis and analysis.trade:
+            trade_counts[analysis.trade] = trade_counts.get(analysis.trade, 0) + 1
+        if analysis and analysis.document_type_detected:
+            t = analysis.document_type_detected
+            type_counts[t] = type_counts.get(t, 0) + 1
+
+    pending_jobs = TriageJob.query.filter(
+        TriageJob.bid_package_id == package_id,
+        TriageJob.status.in_(("pending", "running")),
+    ).count()
+
+    return render_template(
+        "bid_package_index.html",
+        project=project,
+        package=package,
+        rows=rows,
+        trade_counts=sorted(trade_counts.items(), key=lambda x: -x[1]),
+        type_counts=sorted(type_counts.items(), key=lambda x: -x[1]),
+        pending_jobs=pending_jobs,
+        analyzed_count=sum(1 for r in rows if r["status"] in ("analyzed", "needs_review")),
+    )
+
+
+@app.route("/projects/<project_id>/bid-package/<package_id>/analyze", methods=["POST"])
+@login_required
+def bid_package_analyze(project_id, package_id):
+    """Enqueue per-document analysis jobs for the package."""
+    project = db.session.get(Project, project_id)
+    if not _can_access_project(project):
+        abort(404)
+    package = db.session.get(BidPackage, package_id)
+    if not package or package.project_id != project_id:
+        abort(404)
+
+    from triage_worker import enqueue_package_analysis
+
+    enqueued = enqueue_package_analysis(package, user_id=current_user.id)
+    _log_activity("bid_package_analyze", f"Enqueued {enqueued} analyses", project_id)
+    if enqueued == 0:
+        flash("All documents in this bid package are already analyzed.", "success")
+    else:
+        flash(
+            f"Queued {enqueued} document(s) for analysis. The page will update as the worker processes them.",
+            "success",
+        )
+    return redirect(url_for("bid_package_index", project_id=project_id, package_id=package_id))
+
+
+@app.route("/projects/<project_id>/bid-package/<package_id>/document/<document_id>/review", methods=["POST"])
+@login_required
+def bid_package_set_review(project_id, package_id, document_id):
+    """AE marks a document Reviewed / Flagged / Unreviewed and adds notes."""
+    project = db.session.get(Project, project_id)
+    if not _can_access_project(project):
+        abort(404)
+    doc = db.session.get(ProjectDocument, document_id)
+    if not doc or doc.project_id != project_id or doc.bid_package_id != package_id:
+        abort(404)
+    analysis = doc.analysis
+    if analysis is None:
+        flash("Run analysis on this document first.", "error")
+        return redirect(url_for("bid_package_index", project_id=project_id, package_id=package_id))
+
+    new_status = request.form.get("reviewer_status", "").strip()
+    if new_status not in ("unreviewed", "reviewed", "flagged"):
+        flash("Invalid review status.", "error")
+        return redirect(url_for("bid_package_index", project_id=project_id, package_id=package_id))
+
+    analysis.reviewer_status = new_status
+    analysis.reviewer_notes = request.form.get("reviewer_notes", "").strip()
+    analysis.reviewed_by = current_user.id
+    analysis.reviewed_at = datetime.now(timezone.utc)
+    db.session.commit()
+    flash("Document review state saved.", "success")
+    return redirect(url_for("bid_package_index", project_id=project_id, package_id=package_id))
+
+
+@app.route("/projects/<project_id>/bid-package/<package_id>.xlsx", methods=["GET"])
+@login_required
+def bid_package_xlsx(project_id, package_id):
+    """Export the per-document index as an XLSX so it can be shared with stakeholders."""
+    project = db.session.get(Project, project_id)
+    if not _can_access_project(project):
+        abort(404)
+    package = db.session.get(BidPackage, package_id)
+    if not package or package.project_id != project_id:
+        abort(404)
+
+    import io as _io
+    from openpyxl import Workbook
+
+    wb = Workbook()
+    ws = wb.active
+    ws.title = "Bid Package Index"
+    ws.append([
+        "Relative Path",
+        "Filename",
+        "Trade",
+        "Document Type",
+        "Addendum",
+        "Synopsis",
+        "Status",
+        "Reviewer Status",
+        "Confidence",
+        "Needs OCR",
+        "File Size (bytes)",
+    ])
+
+    documents = (
+        ProjectDocument.query.filter_by(bid_package_id=package_id)
+        .order_by(ProjectDocument.relative_path.asc())
+        .all()
+    )
+    for doc in documents:
+        a = doc.analysis
+        ws.append([
+            doc.relative_path or "",
+            doc.original_filename,
+            (a.trade if a else "") or "",
+            (a.document_type_detected if a else "") or "",
+            (a.addendum_label if a else "") or "",
+            (a.synopsis if a else "") or "",
+            (a.status if a else "pending"),
+            (a.reviewer_status if a else "unreviewed"),
+            float(a.confidence) if a else 0.0,
+            "yes" if (a and a.needs_ocr) else "no",
+            doc.file_size or 0,
+        ])
+
+    buf = _io.BytesIO()
+    wb.save(buf)
+    buf.seek(0)
+    safe_project = secure_filename(project.name) or project_id
+    return send_file(
+        buf,
+        mimetype="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        as_attachment=True,
+        download_name=f"bid_package_index_{safe_project}.xlsx",
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -2565,11 +2881,7 @@ def apply_feedback(proposal_id):
     # Load supporting context
     owner = _proposal_owner(proposal)
     owner_id = owner.id if owner else current_user.id
-    standards = CompanyStandard.query.filter_by(user_id=owner_id, is_active=True).all()
-    standards_data = [
-        {"category": s.category, "title": s.title, "content": s.content}
-        for s in standards
-    ] if standards else None
+    standards_data = _company_standards_data(owner_id)
 
     corrections = ProposalCorrection.query.filter_by(user_id=owner_id).order_by(
         ProposalCorrection.created_at.desc()
@@ -2960,6 +3272,8 @@ def add_company_standard():
     )
     db.session.add(standard)
     db.session.commit()
+    from etg_knowledge_seed import upsert_from_company_standard
+    upsert_from_company_standard(standard)
     _log_activity("company_standard_add", f"Added standard: {title}")
     flash(f"Company standard '{title}' added.", "success")
     return redirect(url_for("settings") + "#company")
@@ -2977,6 +3291,8 @@ def edit_company_standard(standard_id):
     std.content = request.form.get("standard_content", std.content).strip()
 
     db.session.commit()
+    from etg_knowledge_seed import upsert_from_company_standard
+    upsert_from_company_standard(std)
     _log_activity("company_standard_edit", f"Updated standard: {std.title}")
     flash(f"Standard '{std.title}' updated.", "success")
     return redirect(url_for("settings") + "#company")
@@ -2989,11 +3305,147 @@ def delete_company_standard(standard_id):
     if not std or std.user_id != current_user.id:
         abort(404)
     title = std.title
+    from etg_knowledge_seed import delete_from_company_standard
+    delete_from_company_standard(std)
     db.session.delete(std)
     db.session.commit()
     _log_activity("company_standard_delete", f"Deleted standard: {title}")
     flash(f"Standard '{title}' deleted.", "success")
     return redirect(url_for("settings") + "#company")
+
+
+# ---------------------------------------------------------------------------
+# ETG Knowledge Base (Pre-Proposal Triage Phase 1)
+# ---------------------------------------------------------------------------
+
+ETG_KNOWLEDGE_SECTIONS = [
+    ("company_profile", "Company Profile"),
+    ("capabilities", "Capabilities Matrix"),
+    ("tech_stack", "Technology Stack"),
+    ("sow_boilerplate", "SOW Boilerplate"),
+    ("exclusions", "Exclusions / Assumptions"),
+    ("pricing_reference", "Pricing Reference"),
+    ("past_proposal", "Past Proposal Library"),
+    ("brand_asset", "Brand Assets"),
+    ("taxonomy", "Triage Taxonomy"),
+    ("expected_documents", "Expected Documents Checklist"),
+]
+
+
+def _user_can_edit_global_knowledge() -> bool:
+    return getattr(current_user, "is_admin", False)
+
+
+@app.route("/settings/etg-knowledge", methods=["GET"])
+@login_required
+def etg_knowledge_index():
+    """Browse and manage ETG knowledge assets used to inject context into AI prompts."""
+    from sqlalchemy import or_ as _or
+    assets = (
+        EtgKnowledgeAsset.query.filter(
+            _or(
+                EtgKnowledgeAsset.user_id == current_user.id,
+                EtgKnowledgeAsset.user_id.is_(None),
+            )
+        )
+        .order_by(
+            EtgKnowledgeAsset.section.asc(),
+            EtgKnowledgeAsset.sort_order.asc(),
+            EtgKnowledgeAsset.title.asc(),
+        )
+        .all()
+    )
+    grouped: dict[str, list[EtgKnowledgeAsset]] = {key: [] for key, _ in ETG_KNOWLEDGE_SECTIONS}
+    for asset in assets:
+        grouped.setdefault(asset.section, []).append(asset)
+
+    return render_template(
+        "etg_knowledge.html",
+        sections=ETG_KNOWLEDGE_SECTIONS,
+        grouped=grouped,
+        verticals=VERTICALS,
+        can_edit_global=_user_can_edit_global_knowledge(),
+    )
+
+
+@app.route("/settings/etg-knowledge/add", methods=["POST"])
+@login_required
+def etg_knowledge_add():
+    section = request.form.get("section", "").strip()
+    title = request.form.get("title", "").strip()
+    content_md = request.form.get("content_md", "").strip()
+    vertical = request.form.get("vertical", "").strip()
+    tags = request.form.get("tags", "").strip()
+    is_global = bool(request.form.get("is_global"))
+
+    if section not in {key for key, _ in ETG_KNOWLEDGE_SECTIONS}:
+        flash("Invalid knowledge section.", "error")
+        return redirect(url_for("etg_knowledge_index"))
+    if not title or not content_md:
+        flash("Title and content are required.", "error")
+        return redirect(url_for("etg_knowledge_index"))
+    if is_global and not _user_can_edit_global_knowledge():
+        flash("Only admins can add company-wide (global) knowledge assets.", "error")
+        return redirect(url_for("etg_knowledge_index"))
+
+    asset = EtgKnowledgeAsset(
+        user_id=None if is_global else current_user.id,
+        section=section,
+        title=title,
+        content_md=content_md,
+        vertical=vertical,
+        tags=tags,
+        source="manual",
+    )
+    db.session.add(asset)
+    db.session.commit()
+    _log_activity("etg_knowledge_add", f"Added {section}: {title}")
+    flash(f"Added '{title}' to {section.replace('_', ' ')}.", "success")
+    return redirect(url_for("etg_knowledge_index") + f"#{section}")
+
+
+@app.route("/settings/etg-knowledge/<asset_id>/edit", methods=["POST"])
+@login_required
+def etg_knowledge_edit(asset_id):
+    asset = db.session.get(EtgKnowledgeAsset, asset_id)
+    if not asset:
+        abort(404)
+    if asset.user_id is not None and asset.user_id != current_user.id:
+        abort(404)
+    if asset.user_id is None and not _user_can_edit_global_knowledge():
+        flash("Only admins can edit company-wide knowledge assets.", "error")
+        return redirect(url_for("etg_knowledge_index"))
+
+    asset.title = request.form.get("title", asset.title).strip() or asset.title
+    asset.content_md = request.form.get("content_md", asset.content_md).strip()
+    asset.vertical = request.form.get("vertical", asset.vertical).strip()
+    asset.tags = request.form.get("tags", asset.tags).strip()
+    asset.is_active = bool(request.form.get("is_active"))
+    db.session.commit()
+    _log_activity("etg_knowledge_edit", f"Updated {asset.section}: {asset.title}")
+    flash(f"Updated '{asset.title}'.", "success")
+    return redirect(url_for("etg_knowledge_index") + f"#{asset.section}")
+
+
+@app.route("/settings/etg-knowledge/<asset_id>/delete", methods=["POST"])
+@login_required
+def etg_knowledge_delete(asset_id):
+    asset = db.session.get(EtgKnowledgeAsset, asset_id)
+    if not asset:
+        abort(404)
+    if asset.user_id is not None and asset.user_id != current_user.id:
+        abort(404)
+    if asset.user_id is None and not _user_can_edit_global_knowledge():
+        flash("Only admins can delete company-wide knowledge assets.", "error")
+        return redirect(url_for("etg_knowledge_index"))
+
+    title = asset.title
+    section = asset.section
+    db.session.delete(asset)
+    db.session.commit()
+    _log_activity("etg_knowledge_delete", f"Deleted {section}: {title}")
+    flash(f"Deleted '{title}'.", "success")
+    return redirect(url_for("etg_knowledge_index") + f"#{section}")
 
 
 # ---------------------------------------------------------------------------

--- a/bid_package_service.py
+++ b/bid_package_service.py
@@ -1,0 +1,303 @@
+"""Bid package ingestion service.
+
+Accepts a zip archive (or, for admins, a server-side folder path) and
+registers every document inside as a ``ProjectDocument`` tied to a
+``BidPackage``. Designed to run inside the request handler for small
+packages and to be invoked by the triage worker for large ones.
+
+Constraints honoured:
+
+- Per-package and per-project size caps (configurable; defaults below).
+- SHA-256 dedup within the package (skip identical bytes).
+- Duplicate filename safe-rename (keeps zip subfolder layout intact).
+- Disk-friendly: never holds an entire file in memory; uses streamed copy.
+- Skips obviously-not-document files (zip-internal junk, OS files).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import shutil
+import tempfile
+import uuid
+import zipfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+from werkzeug.utils import secure_filename
+
+from config.settings import UPLOADS_DIR
+from models import BidPackage, ProjectDocument, db
+
+
+# ---------------------------------------------------------------------------
+# Configuration (override in config/settings.py later if needed)
+# ---------------------------------------------------------------------------
+
+MAX_PACKAGE_SIZE_BYTES = int(os.getenv("MAX_BID_PACKAGE_SIZE_MB", "2048")) * 1024 * 1024
+MAX_FILES_PER_PACKAGE = int(os.getenv("MAX_FILES_PER_BID_PACKAGE", "500"))
+
+# Extensions we'll keep. Everything else is silently skipped during ingestion.
+ACCEPTED_EXTENSIONS = {
+    ".pdf",
+    ".docx",
+    ".doc",
+    ".xlsx",
+    ".xls",
+    ".txt",
+    ".md",
+    ".csv",
+    ".dwg",
+    ".dxf",
+    ".rtf",
+}
+
+# OS / archive metadata files we always skip.
+JUNK_PREFIXES = ("__MACOSX/", ".DS_Store", "Thumbs.db", "desktop.ini")
+
+
+class BidPackageError(Exception):
+    """Raised when a bid package can't be accepted."""
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def ingest_zip_filelike(
+    *,
+    project_id: str,
+    user_id: str,
+    file_storage,
+    original_filename: str = "",
+) -> BidPackage:
+    """Ingest a zip uploaded via Flask's file_storage.
+
+    The file is streamed to a temp file, validated, then unpacked into the
+    project's bid_package directory. A BidPackage row is created (status
+    ``ready`` on success, ``failed`` otherwise) and ProjectDocument rows are
+    inserted for every accepted file.
+    """
+    package = BidPackage(
+        project_id=project_id,
+        uploaded_by=user_id,
+        source="zip",
+        original_filename=original_filename or getattr(file_storage, "filename", "") or "",
+        status="ingesting",
+    )
+    db.session.add(package)
+    db.session.commit()
+
+    tmp = tempfile.NamedTemporaryFile(delete=False, suffix=".zip")
+    tmp_path = Path(tmp.name)
+    try:
+        # Stream copy the upload to disk so we can re-open it as a zip.
+        shutil.copyfileobj(file_storage.stream, tmp)
+        tmp.close()
+
+        ingest_zip_path(
+            zip_path=tmp_path,
+            package=package,
+        )
+    except BidPackageError as exc:
+        package.status = "failed"
+        package.error_message = str(exc)
+        package.completed_at = datetime.now(timezone.utc)
+        db.session.commit()
+        raise
+    except Exception as exc:  # pragma: no cover - defensive
+        package.status = "failed"
+        package.error_message = f"Unexpected error: {exc}"
+        package.completed_at = datetime.now(timezone.utc)
+        db.session.commit()
+        raise
+    finally:
+        try:
+            tmp_path.unlink(missing_ok=True)
+        except Exception:
+            pass
+
+    return package
+
+
+def ingest_zip_path(*, zip_path: Path, package: BidPackage) -> None:
+    """Unpack ``zip_path`` into the package's directory and register documents."""
+    package_dir = _package_dir(package.project_id, package.id)
+    package_dir.mkdir(parents=True, exist_ok=True)
+
+    with zipfile.ZipFile(zip_path) as zf:
+        members = [m for m in zf.infolist() if not m.is_dir()]
+        members = [m for m in members if not _is_junk(m.filename)]
+        members = [m for m in members if _has_accepted_extension(m.filename)]
+
+        if len(members) > MAX_FILES_PER_PACKAGE:
+            raise BidPackageError(
+                f"Bid package contains {len(members)} files; the per-package "
+                f"limit is {MAX_FILES_PER_PACKAGE}. Split it into smaller "
+                "uploads or contact an administrator to raise the cap."
+            )
+
+        # Preflight size sanity check.
+        total = sum(m.file_size for m in members)
+        if total > MAX_PACKAGE_SIZE_BYTES:
+            raise BidPackageError(
+                f"Bid package uncompressed size is {_human_size(total)}; the "
+                f"limit is {_human_size(MAX_PACKAGE_SIZE_BYTES)}."
+            )
+
+        seen_hashes: set[str] = set()
+        accepted = 0
+        duplicates = 0
+        skipped = 0
+
+        for member in members:
+            try:
+                accepted_one, hash_seen = _extract_one(zf, member, package, package_dir, seen_hashes)
+            except BidPackageError:
+                raise
+            except Exception:
+                skipped += 1
+                continue
+
+            if accepted_one:
+                accepted += 1
+                if hash_seen:
+                    seen_hashes.add(hash_seen)
+            else:
+                duplicates += 1
+
+        package.file_count = accepted
+        package.duplicate_count = duplicates
+        package.skipped_count = skipped
+        package.total_size_bytes = _dir_size(package_dir)
+        package.status = "ready"
+        package.completed_at = datetime.now(timezone.utc)
+        db.session.commit()
+
+
+def list_documents_for_package(package_id: str):
+    """All ProjectDocument rows tied to a package, ordered by relative path."""
+    return (
+        ProjectDocument.query.filter_by(bid_package_id=package_id)
+        .order_by(ProjectDocument.relative_path.asc())
+        .all()
+    )
+
+
+# ---------------------------------------------------------------------------
+# Internals
+# ---------------------------------------------------------------------------
+
+
+def _extract_one(
+    zf: zipfile.ZipFile,
+    member: zipfile.ZipInfo,
+    package: BidPackage,
+    package_dir: Path,
+    seen_hashes: set[str],
+) -> tuple[bool, str | None]:
+    """Extract one zip member; return (accepted, sha256_if_accepted)."""
+    rel_path = _safe_relative_path(member.filename)
+    dest_path = package_dir / rel_path
+    dest_path.parent.mkdir(parents=True, exist_ok=True)
+
+    # Stream copy + hash in one pass.
+    sha = hashlib.sha256()
+    written = 0
+    with zf.open(member) as src, open(dest_path, "wb") as dst:
+        while True:
+            chunk = src.read(64 * 1024)
+            if not chunk:
+                break
+            sha.update(chunk)
+            dst.write(chunk)
+            written += len(chunk)
+
+    digest = sha.hexdigest()
+
+    # Dedup: same hash in this package OR same hash already in this project.
+    if digest in seen_hashes:
+        try:
+            dest_path.unlink(missing_ok=True)
+        except Exception:
+            pass
+        return False, None
+
+    existing = ProjectDocument.query.filter_by(
+        project_id=package.project_id, sha256=digest
+    ).first()
+    if existing is not None:
+        try:
+            dest_path.unlink(missing_ok=True)
+        except Exception:
+            pass
+        return False, None
+
+    safe_name = secure_filename(Path(rel_path).name) or f"document_{uuid.uuid4().hex[:8]}"
+    doc = ProjectDocument(
+        project_id=package.project_id,
+        filename=f"{uuid.uuid4().hex[:8]}_{safe_name}",
+        original_filename=Path(rel_path).name,
+        file_type="bid_package",
+        file_path=str(dest_path),
+        file_size=written,
+        bid_package_id=package.id,
+        relative_path=str(rel_path),
+        sha256=digest,
+    )
+    db.session.add(doc)
+    return True, digest
+
+
+def _package_dir(project_id: str, package_id: str) -> Path:
+    return UPLOADS_DIR / "projects" / project_id / "bid_packages" / package_id
+
+
+def _safe_relative_path(name: str) -> Path:
+    """Reject zip-slip and reduce to a safe relative path."""
+    # Normalize separators, drop drive letters, collapse traversal.
+    parts = []
+    for raw in Path(name.replace("\\", "/")).parts:
+        if raw in ("", ".", ".."):
+            continue
+        if raw.endswith(":"):
+            # Drive letter on Windows-style entries
+            continue
+        parts.append(secure_filename(raw) or "_")
+    if not parts:
+        parts = [f"file_{uuid.uuid4().hex[:8]}"]
+    return Path(*parts)
+
+
+def _has_accepted_extension(name: str) -> bool:
+    return Path(name).suffix.lower() in ACCEPTED_EXTENSIONS
+
+
+def _is_junk(name: str) -> bool:
+    base = name.split("/")[-1]
+    if name.startswith(JUNK_PREFIXES):
+        return True
+    return base in {".DS_Store", "Thumbs.db", "desktop.ini"}
+
+
+def _dir_size(p: Path) -> int:
+    total = 0
+    if not p.exists():
+        return 0
+    for entry in p.rglob("*"):
+        try:
+            if entry.is_file():
+                total += entry.stat().st_size
+        except OSError:
+            continue
+    return total
+
+
+def _human_size(n: int) -> str:
+    for unit in ("B", "KB", "MB", "GB"):
+        if n < 1024 or unit == "GB":
+            return f"{n:.1f} {unit}"
+        n /= 1024
+    return f"{n:.1f} GB"

--- a/context_retrieval.py
+++ b/context_retrieval.py
@@ -1,0 +1,156 @@
+"""ETG knowledge retrieval helper.
+
+Pulls relevant entries from the ``etg_knowledge_assets`` table for injection
+into AI prompts. Phase 1 implementation is deterministic (section + vertical
++ tag filtering, deterministic ordering, fixed character budget). A future
+phase can add embedding-based retrieval; the function signature is designed
+to remain stable.
+
+Sections (the ``section`` column on ``EtgKnowledgeAsset``):
+
+- ``company_profile``: company overview, mission, history.
+- ``capabilities``: capability matrix entries by vertical.
+- ``tech_stack``: technology platforms with depth ratings.
+- ``sow_boilerplate``: standard SOW language, versioned by vertical.
+- ``exclusions``: standard exclusions / assumptions library.
+- ``pricing_reference``: labor rates, hours-per-IO heuristics, markups.
+- ``past_proposal``: indexed past proposals with tags.
+- ``brand_asset``: logos, letterheads, brand color palettes.
+- ``taxonomy``: triage taxonomy (trade list, document type list).
+- ``expected_documents``: per-vertical checklist of expected doc types.
+"""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+from models import EtgKnowledgeAsset
+
+
+# Default per-call character budget. Plenty for Haiku tasks; the proposal
+# generator can request a larger budget when it needs the full library.
+DEFAULT_BUDGET = 8000
+
+
+def retrieve_context(
+    sections: Iterable[str],
+    *,
+    user_id: str | None = None,
+    vertical: str | None = None,
+    tags: Iterable[str] | None = None,
+    max_chars: int = DEFAULT_BUDGET,
+) -> str:
+    """Return a Markdown-formatted context block ready to drop into a prompt.
+
+    Empty string when nothing matches. Caller is responsible for prefixing
+    a heading like ``## Company Context``.
+    """
+    sections = list(sections)
+    if not sections:
+        return ""
+
+    query = EtgKnowledgeAsset.query.filter(
+        EtgKnowledgeAsset.section.in_(sections),
+        EtgKnowledgeAsset.is_active.is_(True),
+    )
+
+    if user_id is not None:
+        # User-scoped assets plus globals (user_id null).
+        query = query.filter(
+            db_or(EtgKnowledgeAsset.user_id == user_id, EtgKnowledgeAsset.user_id.is_(None))
+        )
+    else:
+        query = query.filter(EtgKnowledgeAsset.user_id.is_(None))
+
+    rows = query.order_by(
+        EtgKnowledgeAsset.section.asc(),
+        EtgKnowledgeAsset.sort_order.asc(),
+        EtgKnowledgeAsset.created_at.asc(),
+    ).all()
+
+    rows = _filter_by_vertical(rows, vertical)
+    if tags:
+        rows = _filter_by_tags(rows, list(tags))
+
+    if not rows:
+        return ""
+
+    blocks: list[str] = []
+    used = 0
+    for row in rows:
+        block = _format_asset(row)
+        if not block:
+            continue
+        if used + len(block) > max_chars:
+            blocks.append("\n[...additional context truncated for length...]\n")
+            break
+        blocks.append(block)
+        used += len(block)
+
+    return "\n".join(blocks).strip()
+
+
+def list_assets(
+    *,
+    user_id: str | None = None,
+    section: str | None = None,
+) -> list[EtgKnowledgeAsset]:
+    """List assets visible to a user (their own + globals), optionally one section."""
+    query = EtgKnowledgeAsset.query
+    if user_id is not None:
+        query = query.filter(
+            db_or(EtgKnowledgeAsset.user_id == user_id, EtgKnowledgeAsset.user_id.is_(None))
+        )
+    else:
+        query = query.filter(EtgKnowledgeAsset.user_id.is_(None))
+    if section:
+        query = query.filter(EtgKnowledgeAsset.section == section)
+    return query.order_by(
+        EtgKnowledgeAsset.section.asc(),
+        EtgKnowledgeAsset.sort_order.asc(),
+        EtgKnowledgeAsset.title.asc(),
+    ).all()
+
+
+# ---------------------------------------------------------------------------
+# Internals
+# ---------------------------------------------------------------------------
+
+
+def db_or(*clauses):
+    """Tiny wrapper so callers don't have to import sqlalchemy.or_."""
+    from sqlalchemy import or_ as _or
+    return _or(*clauses)
+
+
+def _filter_by_vertical(rows, vertical):
+    if not vertical:
+        # Caller didn't constrain. Return everything (vertical-specific entries
+        # are still useful as general context).
+        return rows
+    return [r for r in rows if not r.vertical or r.vertical == vertical]
+
+
+def _filter_by_tags(rows, tags):
+    wanted = {t.strip().lower() for t in tags if t.strip()}
+    if not wanted:
+        return rows
+    out = []
+    for r in rows:
+        row_tags = {t.strip().lower() for t in (r.tags or "").split(",") if t.strip()}
+        if not row_tags or row_tags & wanted:
+            out.append(r)
+    return out
+
+
+def _format_asset(row: EtgKnowledgeAsset) -> str:
+    """Render a single asset as a Markdown block."""
+    section_label = (row.section or "").replace("_", " ").title() or "Knowledge"
+    title = row.title or "Untitled"
+    body = (row.content_md or "").strip()
+    if not body:
+        return ""
+    header = f"### {section_label}: {title}"
+    if row.vertical:
+        header += f"  _(vertical: {row.vertical})_"
+    return f"\n{header}\n{body}\n"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,3 +29,24 @@ services:
       - ./reference_documents:/app/reference_documents
       - ./config:/app/config
       - ./data:/app/data
+
+  triage-worker:
+    build: .
+    restart: unless-stopped
+    # Runs the pre-proposal triage queue. Polls the SQLite-backed
+    # triage_jobs table and processes per-document analysis tasks. Sharing
+    # the host network keeps DB access (sqlite file mount) and outbound
+    # Anthropic API egress simple.
+    network_mode: host
+    command: ["python", "triage_worker.py"]
+    env_file:
+      - .env
+    volumes:
+      - ./uploads:/app/uploads
+      - ./generated_proposals:/app/generated_proposals
+      - ./templates:/app/templates
+      - ./reference_documents:/app/reference_documents
+      - ./config:/app/config
+      - ./data:/app/data
+    depends_on:
+      - proposal-manager

--- a/etg_knowledge_seed.py
+++ b/etg_knowledge_seed.py
@@ -1,0 +1,272 @@
+"""Seed the EtgKnowledgeAsset table with system defaults and migrate rows
+from the legacy CompanyStandard table.
+
+Called once on app startup. Idempotent: existing rows with matching
+(source, title) are left alone. Adding new entries here is safe and they'll
+appear on the next boot.
+"""
+
+from __future__ import annotations
+
+from models import CompanyStandard, EtgKnowledgeAsset, db
+
+
+# System-global taxonomy used by the per-document analyzer. Editing these in
+# Settings overrides the seed (the user copy wins because the seed only
+# inserts rows that don't already exist).
+TRADE_TAXONOMY = [
+    "general",
+    "electrical",
+    "instrumentation",
+    "automation_controls",
+    "process_mechanical",
+    "piping_pid",
+    "structural_civil",
+    "hvac",
+    "building_automation",
+    "networking_cybersecurity",
+    "validation_qualification",
+    "commissioning",
+    "safety",
+    "project_management",
+]
+
+DOCUMENT_TYPE_TAXONOMY = [
+    "rfp_narrative",
+    "specification",
+    "datasheet",
+    "drawing",
+    "sequence_of_operations",
+    "io_list",
+    "bill_of_materials",
+    "schedule",
+    "addendum",
+    "contract_legal",
+    "submittal",
+    "vendor_proposal",
+    "rfp_qa_log",
+    "checklist",
+    "report",
+    "uncategorized",
+]
+
+
+# Per-vertical "what we expect to see in a complete bid package" lists.
+# These drive the gaps & risks section in Phase 2 but the rows are seeded now
+# so they're editable from day one.
+EXPECTED_DOCUMENTS_BY_VERTICAL = {
+    "life_science": [
+        ("RFP Narrative / Statement of Work", True),
+        ("Process & Instrumentation Diagrams (P&IDs)", True),
+        ("Sequence of Operations (SOO)", True),
+        ("IO Point Schedule", True),
+        ("Equipment Datasheets", True),
+        ("Validation Master Plan / IQ-OQ-PQ Strategy", True),
+        ("Commissioning Protocol / Cx Plan", True),
+        ("Cybersecurity / 21 CFR Part 11 Requirements", True),
+        ("Project Schedule (Gantt or Milestone List)", False),
+        ("Contract Terms & Conditions", False),
+    ],
+    "data_center": [
+        ("RFP Narrative / Statement of Work", True),
+        ("BMS / EPMS Sequence of Operations", True),
+        ("Single-Line Diagrams", True),
+        ("IO Point Schedule", True),
+        ("Equipment Datasheets (UPS, switchgear, CRAH)", True),
+        ("Network / Cybersecurity Requirements", True),
+        ("Commissioning Plan / Lvl 1-5 Cx", True),
+        ("Acceptance Test Procedures", False),
+        ("Project Schedule", False),
+        ("Contract Terms & Conditions", False),
+    ],
+    "food_beverage": [
+        ("RFP Narrative / Statement of Work", True),
+        ("Process & Instrumentation Diagrams (P&IDs)", True),
+        ("Sequence of Operations (SOO)", True),
+        ("IO Point Schedule", True),
+        ("Equipment Datasheets", True),
+        ("Sanitary / Hygienic Design Requirements", True),
+        ("HACCP / Food Safety Plan References", False),
+        ("Commissioning / FAT-SAT Plan", False),
+        ("Project Schedule", False),
+        ("Contract Terms & Conditions", False),
+    ],
+    "general": [
+        ("RFP Narrative / Statement of Work", True),
+        ("Specifications", True),
+        ("Drawings", True),
+        ("IO Point Schedule or Equivalent", False),
+        ("Sequence of Operations (SOO)", False),
+        ("Project Schedule", False),
+        ("Contract Terms & Conditions", False),
+    ],
+}
+
+
+def seed_system_assets() -> int:
+    """Insert system-global rows that don't already exist. Returns inserted count."""
+    inserted = 0
+
+    # Taxonomy entries — one row per section so they show up in Settings.
+    inserted += _ensure_global(
+        section="taxonomy",
+        title="Trades",
+        content_md="\n".join(f"- {t}" for t in TRADE_TAXONOMY),
+        tags="taxonomy,trades",
+        source="system_seed",
+    )
+    inserted += _ensure_global(
+        section="taxonomy",
+        title="Document Types",
+        content_md="\n".join(f"- {t}" for t in DOCUMENT_TYPE_TAXONOMY),
+        tags="taxonomy,document_types",
+        source="system_seed",
+    )
+
+    # Expected-document checklists per vertical.
+    for vertical, items in EXPECTED_DOCUMENTS_BY_VERTICAL.items():
+        body_lines = []
+        for label, required in items:
+            marker = "REQUIRED" if required else "optional"
+            body_lines.append(f"- [{marker}] {label}")
+        inserted += _ensure_global(
+            section="expected_documents",
+            title=f"Expected Documents — {vertical.replace('_', ' ').title()}",
+            content_md="\n".join(body_lines),
+            vertical=vertical,
+            tags=f"expected_documents,{vertical}",
+            source="system_seed",
+        )
+
+    if inserted:
+        db.session.commit()
+    return inserted
+
+
+def migrate_company_standards() -> int:
+    """Copy CompanyStandard rows into EtgKnowledgeAsset. Idempotent.
+
+    Each CompanyStandard becomes a per-user knowledge asset under the
+    ``company_profile`` section (the closest semantic match). The original
+    rows are left untouched so the existing Settings UI keeps working until
+    the next phase removes it.
+    """
+    inserted = 0
+    standards = CompanyStandard.query.filter_by(is_active=True).all()
+    for s in standards:
+        exists = EtgKnowledgeAsset.query.filter_by(
+            user_id=s.user_id,
+            source="migrated_company_standard",
+            title=s.title,
+        ).first()
+        if exists:
+            continue
+        asset = EtgKnowledgeAsset(
+            user_id=s.user_id,
+            section=_section_for_standard_category(s.category),
+            title=s.title,
+            content_md=s.content,
+            tags=f"migrated,{s.category.lower().replace(' ', '_')}",
+            source="migrated_company_standard",
+        )
+        db.session.add(asset)
+        inserted += 1
+    if inserted:
+        db.session.commit()
+    return inserted
+
+
+# ---------------------------------------------------------------------------
+# Internals
+# ---------------------------------------------------------------------------
+
+
+def _ensure_global(
+    *,
+    section: str,
+    title: str,
+    content_md: str,
+    vertical: str = "",
+    tags: str = "",
+    source: str = "system_seed",
+) -> int:
+    existing = EtgKnowledgeAsset.query.filter_by(
+        user_id=None, section=section, title=title
+    ).first()
+    if existing:
+        return 0
+    asset = EtgKnowledgeAsset(
+        user_id=None,
+        section=section,
+        title=title,
+        content_md=content_md,
+        vertical=vertical,
+        tags=tags,
+        source=source,
+    )
+    db.session.add(asset)
+    return 1
+
+
+_CATEGORY_TO_SECTION = {
+    "Mission Statement": "company_profile",
+    "Company Overview": "company_profile",
+    "Certifications": "company_profile",
+    "Past Performance": "past_proposal",
+    "Safety Record": "company_profile",
+    "Quality Standards": "company_profile",
+    "Insurance": "company_profile",
+    "Terms & Conditions": "sow_boilerplate",
+    "Key Personnel": "company_profile",
+    "Differentiators": "company_profile",
+    "Other": "company_profile",
+}
+
+
+def _section_for_standard_category(category: str) -> str:
+    return _CATEGORY_TO_SECTION.get(category, "company_profile")
+
+
+def upsert_from_company_standard(standard) -> EtgKnowledgeAsset:
+    """Mirror a CompanyStandard write into the knowledge base.
+
+    Used by the legacy Settings UI so the proposal generator can read from
+    EtgKnowledgeAsset alone. Returns the upserted asset.
+    """
+    asset = EtgKnowledgeAsset.query.filter_by(
+        user_id=standard.user_id,
+        source="migrated_company_standard",
+        title=standard.title,
+    ).first()
+    section = _section_for_standard_category(standard.category)
+    tags = f"migrated,{standard.category.lower().replace(' ', '_')}"
+    if asset is None:
+        asset = EtgKnowledgeAsset(
+            user_id=standard.user_id,
+            section=section,
+            title=standard.title,
+            content_md=standard.content,
+            tags=tags,
+            source="migrated_company_standard",
+        )
+        db.session.add(asset)
+    else:
+        asset.section = section
+        asset.title = standard.title
+        asset.content_md = standard.content
+        asset.tags = tags
+        asset.is_active = standard.is_active
+    db.session.commit()
+    return asset
+
+
+def delete_from_company_standard(standard) -> None:
+    """Remove the mirrored knowledge asset when its CompanyStandard is deleted."""
+    asset = EtgKnowledgeAsset.query.filter_by(
+        user_id=standard.user_id,
+        source="migrated_company_standard",
+        title=standard.title,
+    ).first()
+    if asset is not None:
+        db.session.delete(asset)
+        db.session.commit()

--- a/models.py
+++ b/models.py
@@ -110,6 +110,11 @@ class ProjectDocument(db.Model):
     version_group = db.Column(db.String(32), default="")  # Groups document versions together
     version_label = db.Column(db.String(100), default="")  # e.g., "Addendum 1", "Rev B"
 
+    # Pre-Proposal Triage (Phase 1)
+    bid_package_id = db.Column(db.String(32), db.ForeignKey("bid_packages.id"), nullable=True)
+    relative_path = db.Column(db.String(1000), default="")  # path within the bid package (preserves zip subfolder structure)
+    sha256 = db.Column(db.String(64), default="", index=True)
+
     tags = db.relationship("DocumentTag", backref="document", lazy="dynamic", cascade="all, delete-orphan")
 
 
@@ -633,3 +638,143 @@ class RevisionTemplate(db.Model):
     created_at = db.Column(db.DateTime, default=_utcnow)
 
     user = db.relationship("User", backref="revision_templates")
+
+
+# ---------------------------------------------------------------------------
+# Pre-Proposal Triage (Phase 1)
+# ---------------------------------------------------------------------------
+
+
+class BidPackage(db.Model):
+    """A bulk upload of bid documents tied to a single project.
+
+    Created when an AE uploads a zip archive (or chooses a server-side folder)
+    containing all documents from a customer bid package. Acts as the parent
+    record for the per-document triage analysis.
+    """
+    __tablename__ = "bid_packages"
+
+    id = db.Column(db.String(32), primary_key=True, default=_uuid)
+    project_id = db.Column(db.String(32), db.ForeignKey("projects.id"), nullable=False)
+    uploaded_by = db.Column(db.String(32), db.ForeignKey("users.id"), nullable=True)
+    source = db.Column(db.String(20), default="zip")  # zip, folder, manual
+    original_filename = db.Column(db.String(500), default="")
+    total_size_bytes = db.Column(db.BigInteger, default=0)
+    file_count = db.Column(db.Integer, default=0)
+    duplicate_count = db.Column(db.Integer, default=0)
+    skipped_count = db.Column(db.Integer, default=0)
+    status = db.Column(db.String(20), default="ingesting")  # ingesting, ready, failed
+    error_message = db.Column(db.Text, default="")
+    notes = db.Column(db.Text, default="")
+    ingested_at = db.Column(db.DateTime, default=_utcnow)
+    completed_at = db.Column(db.DateTime, nullable=True)
+
+    project = db.relationship("Project", backref="bid_packages")
+    uploader = db.relationship("User")
+
+
+class DocumentAnalysis(db.Model):
+    """Per-document triage analysis: trade, type, addendum, synopsis, entities.
+
+    Populated by the triage worker after each document is classified. One row
+    per ProjectDocument that has been (or is being) analyzed.
+    """
+    __tablename__ = "document_analyses"
+    __table_args__ = (
+        db.UniqueConstraint("document_id", name="uq_document_analysis"),
+    )
+
+    id = db.Column(db.String(32), primary_key=True, default=_uuid)
+    document_id = db.Column(db.String(32), db.ForeignKey("project_documents.id"), nullable=False)
+    project_id = db.Column(db.String(32), db.ForeignKey("projects.id"), nullable=False)
+    bid_package_id = db.Column(db.String(32), db.ForeignKey("bid_packages.id"), nullable=True)
+
+    # Classification
+    trade = db.Column(db.String(80), default="")  # electrical, instrumentation, automation, etc.
+    document_type_detected = db.Column(db.String(80), default="")  # specification, datasheet, drawing, etc.
+    addendum_label = db.Column(db.String(80), default="")  # Base, Addendum 1, Rev B, etc.
+
+    # Content
+    synopsis = db.Column(db.Text, default="")  # ~25-word factual summary
+    key_entities = db.Column(db.Text, default="")  # JSON: {"systems": [...], "io_count": N, ...}
+
+    # Quality flags
+    text_length = db.Column(db.Integer, default=0)
+    needs_ocr = db.Column(db.Boolean, default=False)
+    confidence = db.Column(db.Float, default=0.0)  # 0.0..1.0 from the model
+
+    # Pipeline state
+    status = db.Column(db.String(20), default="pending")  # pending, analyzing, analyzed, needs_review, failed
+    error_message = db.Column(db.Text, default="")
+    llm_model = db.Column(db.String(100), default="")
+    analyzed_at = db.Column(db.DateTime, nullable=True)
+
+    # AE review
+    reviewer_status = db.Column(db.String(20), default="unreviewed")  # unreviewed, reviewed, flagged
+    reviewer_notes = db.Column(db.Text, default="")
+    reviewed_by = db.Column(db.String(32), db.ForeignKey("users.id"), nullable=True)
+    reviewed_at = db.Column(db.DateTime, nullable=True)
+
+    created_at = db.Column(db.DateTime, default=_utcnow)
+    updated_at = db.Column(db.DateTime, default=_utcnow, onupdate=_utcnow)
+
+    document = db.relationship("ProjectDocument", backref=db.backref("analysis", uselist=False))
+    project = db.relationship("Project")
+    bid_package = db.relationship("BidPackage", backref="analyses")
+    reviewer = db.relationship("User", foreign_keys=[reviewed_by])
+
+
+class EtgKnowledgeAsset(db.Model):
+    """Structured ETG knowledge base used to inject company context into AI prompts.
+
+    Replaces the looser CompanyStandard model with a tagged, vertical-aware
+    library. Each asset has a section (company_profile, capabilities, tech_stack,
+    sow_boilerplate, exclusions, pricing_reference, past_proposal, taxonomy,
+    expected_documents, brand_asset) so the retrieval helper can pull only what's
+    relevant per task without blowing the context window.
+    """
+    __tablename__ = "etg_knowledge_assets"
+
+    id = db.Column(db.String(32), primary_key=True, default=_uuid)
+    user_id = db.Column(db.String(32), db.ForeignKey("users.id"), nullable=True)  # null = system/global
+    section = db.Column(db.String(40), nullable=False, index=True)
+    title = db.Column(db.String(300), nullable=False)
+    content_md = db.Column(db.Text, default="")
+    file_path = db.Column(db.String(1000), default="")
+    vertical = db.Column(db.String(50), default="")  # blank = applies to all verticals
+    tags = db.Column(db.Text, default="")  # comma-separated tags for retrieval filtering
+    is_active = db.Column(db.Boolean, default=True)
+    sort_order = db.Column(db.Integer, default=0)
+    source = db.Column(db.String(40), default="manual")  # manual, migrated_company_standard, system_seed
+    created_at = db.Column(db.DateTime, default=_utcnow)
+    updated_at = db.Column(db.DateTime, default=_utcnow, onupdate=_utcnow)
+
+    user = db.relationship("User", backref="etg_knowledge_assets")
+
+
+class TriageJob(db.Model):
+    """Background work items for the triage worker.
+
+    SQLite-backed queue: the worker daemon polls this table for pending rows,
+    claims them with a status update inside a transaction, and runs the
+    associated handler. Keeps the architecture single-service and simple.
+    """
+    __tablename__ = "triage_jobs"
+
+    id = db.Column(db.String(32), primary_key=True, default=_uuid)
+    project_id = db.Column(db.String(32), db.ForeignKey("projects.id"), nullable=True)
+    bid_package_id = db.Column(db.String(32), db.ForeignKey("bid_packages.id"), nullable=True)
+    document_id = db.Column(db.String(32), db.ForeignKey("project_documents.id"), nullable=True)
+    user_id = db.Column(db.String(32), db.ForeignKey("users.id"), nullable=True)
+
+    job_type = db.Column(db.String(40), nullable=False)  # ingest_zip, analyze_document
+    payload = db.Column(db.Text, default="")  # JSON for handler-specific args
+    status = db.Column(db.String(20), default="pending", index=True)  # pending, running, done, failed
+    attempts = db.Column(db.Integer, default=0)
+    max_attempts = db.Column(db.Integer, default=2)
+    error_message = db.Column(db.Text, default="")
+
+    created_at = db.Column(db.DateTime, default=_utcnow)
+    started_at = db.Column(db.DateTime, nullable=True)
+    finished_at = db.Column(db.DateTime, nullable=True)
+    heartbeat_at = db.Column(db.DateTime, nullable=True)

--- a/test_triage.py
+++ b/test_triage.py
@@ -1,0 +1,321 @@
+"""Tests for the Pre-Proposal Triage Phase 1 feature.
+
+Mirrors the style of test_features.py: custom `test()` helper, in-memory
+SQLite, no pytest. Run with `python test_triage.py`.
+"""
+from __future__ import annotations
+
+import io
+import os
+import sys
+import zipfile
+
+os.environ['FLASK_SECRET_KEY'] = 'test-secret-key-12345'
+
+from app import app, db  # noqa: E402
+from bid_package_service import (  # noqa: E402
+    BidPackageError,
+    MAX_PACKAGE_SIZE_BYTES,
+    ingest_zip_filelike,
+)
+from context_retrieval import retrieve_context  # noqa: E402
+from etg_knowledge_seed import (  # noqa: E402
+    migrate_company_standards,
+    seed_system_assets,
+    upsert_from_company_standard,
+)
+from models import (  # noqa: E402
+    BidPackage,
+    CompanyStandard,
+    DocumentAnalysis,
+    EtgKnowledgeAsset,
+    Project,
+    ProjectDocument,
+    TriageJob,
+    User,
+)
+
+app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+app.config['TESTING'] = True
+
+passed = 0
+failed = 0
+
+
+def test(name: str, condition: bool, detail: str = ""):
+    global passed, failed
+    if condition:
+        passed += 1
+        print(f"  PASS: {name}")
+    else:
+        failed += 1
+        print(f"  FAIL: {name} - {detail}")
+
+
+def make_zip(files: dict[str, bytes]) -> io.BytesIO:
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+        for name, data in files.items():
+            zf.writestr(name, data)
+    buf.seek(0)
+    return buf
+
+
+with app.app_context():
+    db.drop_all()
+    db.create_all()
+    client = app.test_client()
+
+    # ===== AUTH =====
+    print("\n=== Auth & Setup ===")
+    client.post('/signup', data={
+        'username': 'aeuser', 'email': 'ae@etg.test',
+        'password': 'testpass123', 'display_name': 'Stephanie',
+        'company_name': 'E Tech Group',
+    })
+    client.post('/login', data={'username': 'aeuser', 'password': 'testpass123'})
+    user = User.query.filter_by(username='aeuser').first()
+    test("User created", user is not None)
+
+    # ===== ETG KNOWLEDGE SEED =====
+    print("\n=== ETG Knowledge Seed ===")
+    seed_system_assets()
+    taxonomy_count = EtgKnowledgeAsset.query.filter_by(
+        user_id=None, section='taxonomy'
+    ).count()
+    expected_count = EtgKnowledgeAsset.query.filter_by(
+        user_id=None, section='expected_documents'
+    ).count()
+    test("System taxonomy seeded", taxonomy_count >= 2,
+         f"got {taxonomy_count}")
+    test("Expected-document checklists seeded for verticals",
+         expected_count >= 4, f"got {expected_count}")
+
+    # Idempotency: running again does not duplicate.
+    seed_system_assets()
+    test("Seed is idempotent",
+         EtgKnowledgeAsset.query.filter_by(user_id=None, section='taxonomy').count()
+         == taxonomy_count)
+
+    # ===== COMPANY STANDARD MIGRATION =====
+    print("\n=== CompanyStandard → EtgKnowledgeAsset Mirror ===")
+    cs = CompanyStandard(
+        user_id=user.id,
+        category='Mission Statement',
+        title='ETG Mission',
+        content='Engineer the world\'s most advanced operations.',
+    )
+    db.session.add(cs)
+    db.session.commit()
+
+    upsert_from_company_standard(cs)
+    mirrored = EtgKnowledgeAsset.query.filter_by(
+        user_id=user.id, source='migrated_company_standard', title='ETG Mission'
+    ).first()
+    test("CompanyStandard mirrored to EtgKnowledgeAsset", mirrored is not None)
+    test("Mirror picks correct section",
+         mirrored is not None and mirrored.section == 'company_profile')
+
+    # Idempotency on upsert.
+    upsert_from_company_standard(cs)
+    count = EtgKnowledgeAsset.query.filter_by(
+        user_id=user.id, source='migrated_company_standard', title='ETG Mission'
+    ).count()
+    test("Upsert is idempotent", count == 1)
+
+    # bulk migration helper
+    cs2 = CompanyStandard(
+        user_id=user.id, category='Certifications', title='CSIA Enterprise',
+        content='Certified Enterprise CSI integrator since 2015.',
+    )
+    db.session.add(cs2)
+    db.session.commit()
+    inserted = migrate_company_standards()
+    test("migrate_company_standards inserted new rows", inserted >= 1)
+
+    # ===== CONTEXT RETRIEVAL =====
+    print("\n=== Context Retrieval ===")
+    block = retrieve_context(['company_profile'], user_id=user.id, max_chars=1000)
+    test("Retrieval returns the migrated mission",
+         'ETG Mission' in block, block[:80])
+    block = retrieve_context(['taxonomy'], user_id=user.id, max_chars=200)
+    test("Retrieval honors max_chars", len(block) <= 260,
+         f"len={len(block)}")
+    empty = retrieve_context(['nonexistent_section'], user_id=user.id)
+    test("Retrieval returns empty for missing sections", empty == "")
+
+    # ===== ETG KNOWLEDGE ROUTES =====
+    print("\n=== ETG Knowledge Settings UI ===")
+    resp = client.get('/settings/etg-knowledge')
+    test("ETG knowledge index loads", resp.status_code == 200)
+    test("Index page lists section headings",
+         b'Capabilities Matrix' in resp.data and b'Technology Stack' in resp.data)
+
+    resp = client.post('/settings/etg-knowledge/add', data={
+        'section': 'capabilities',
+        'title': 'Pharma Cleanroom Capability',
+        'content_md': 'ISO 5/7/8 cleanroom MEP/automation experience.',
+        'vertical': 'life_science',
+        'tags': 'cleanroom,pharma',
+    }, follow_redirects=True)
+    test("Add knowledge asset succeeds", resp.status_code == 200)
+    asset = EtgKnowledgeAsset.query.filter_by(
+        user_id=user.id, title='Pharma Cleanroom Capability'
+    ).first()
+    test("Asset persisted", asset is not None)
+    test("Asset section saved",
+         asset is not None and asset.section == 'capabilities')
+
+    # ===== BID PACKAGE INGESTION =====
+    print("\n=== Bid Package Ingestion ===")
+    resp = client.post('/projects/new', data={
+        'project_name': 'Acme Pharma Project',
+        'client_name': 'Acme Bio',
+    }, follow_redirects=False)
+    project = Project.query.filter_by(name='Acme Pharma Project').first()
+    test("Project created for triage test", project is not None)
+
+    zip_contents = {
+        'Base/RFP_Narrative.pdf': b'%PDF-1.4 fake pdf bytes',
+        'Base/Specifications/spec_section_25_5000.txt': (
+            b'Building Management System sequence of operations. '
+            b'Includes IO points and equipment list.'
+        ),
+        'Addendum 1/spec_section_25_5000.txt': (
+            b'Building Management System sequence of operations. '
+            b'Updated agitator capacity and added one more skid.'
+        ),
+        '__MACOSX/junk_file': b'should be skipped',
+    }
+    zip_file = make_zip(zip_contents)
+
+    resp = client.post(
+        f'/projects/{project.id}/bid-package/upload',
+        data={'bid_package_zip': (zip_file, 'acme_bid_package.zip')},
+        content_type='multipart/form-data',
+        follow_redirects=False,
+    )
+    test("Bid package upload returns redirect",
+         resp.status_code == 302, f"got {resp.status_code}")
+
+    package = BidPackage.query.filter_by(project_id=project.id).first()
+    test("Bid package row created", package is not None)
+    test("Bid package status = ready",
+         package is not None and package.status == 'ready',
+         package.status if package else "no package")
+    test("Junk files skipped", package is not None and package.file_count == 3)
+
+    docs = ProjectDocument.query.filter_by(bid_package_id=package.id).all()
+    test("ProjectDocument rows created", len(docs) == 3)
+    test("Documents have sha256",
+         all(d.sha256 for d in docs))
+    test("Documents preserve relative path",
+         any(d.relative_path.startswith('Base/') for d in docs))
+
+    # Re-uploading the same zip should hit the dedup path (same hashes already present).
+    zip_file_2 = make_zip(zip_contents)
+    resp2 = client.post(
+        f'/projects/{project.id}/bid-package/upload',
+        data={'bid_package_zip': (zip_file_2, 'acme_bid_package.zip')},
+        content_type='multipart/form-data',
+        follow_redirects=False,
+    )
+    test("Re-upload returns redirect",
+         resp2.status_code == 302, f"got {resp2.status_code}")
+    packages = BidPackage.query.filter_by(project_id=project.id).all()
+    second = [p for p in packages if p.id != package.id]
+    test("Second package row exists", len(second) == 1)
+    test("Second package ingested zero new docs (all duplicates)",
+         second and second[0].file_count == 0,
+         f"file_count={second[0].file_count if second else 'n/a'}")
+
+    # ===== INDEX PAGE =====
+    print("\n=== Index Page ===")
+    resp = client.get(f'/projects/{project.id}/bid-package')
+    test("Bid package landing loads", resp.status_code == 200)
+    test("Landing shows package listing",
+         b'Bid Packages' in resp.data)
+
+    resp = client.get(f'/projects/{project.id}/bid-package/{package.id}')
+    test("Bid package index loads", resp.status_code == 200)
+    test("Index shows the document filenames",
+         b'spec_section_25_5000' in resp.data)
+
+    # XLSX export.
+    resp = client.get(f'/projects/{project.id}/bid-package/{package.id}.xlsx')
+    test("XLSX export returns 200", resp.status_code == 200)
+    test("XLSX content type set",
+         'spreadsheetml' in resp.headers.get('Content-Type', ''))
+
+    # ===== ANALYSIS QUEUEING =====
+    print("\n=== Analysis Job Queue ===")
+    resp = client.post(
+        f'/projects/{project.id}/bid-package/{package.id}/analyze',
+        follow_redirects=False,
+    )
+    test("Analyze enqueue returns redirect",
+         resp.status_code == 302, f"got {resp.status_code}")
+    queued = TriageJob.query.filter_by(bid_package_id=package.id, status='pending').count()
+    test("Queued one job per document", queued == 3, f"got {queued}")
+
+    # ===== REVIEWER STATUS =====
+    print("\n=== Per-Document Review State ===")
+    sample_doc = docs[0]
+    # Stub an analysis row so the route accepts the review.
+    analysis = DocumentAnalysis(
+        document_id=sample_doc.id,
+        project_id=sample_doc.project_id,
+        bid_package_id=package.id,
+        status='analyzed',
+        synopsis='Test synopsis.',
+    )
+    db.session.add(analysis)
+    db.session.commit()
+
+    resp = client.post(
+        f'/projects/{project.id}/bid-package/{package.id}/document/{sample_doc.id}/review',
+        data={'reviewer_status': 'flagged', 'reviewer_notes': 'Missing IO list?'},
+        follow_redirects=False,
+    )
+    test("Review state save redirects",
+         resp.status_code == 302, f"got {resp.status_code}")
+    db.session.refresh(analysis)
+    test("Review state recorded",
+         analysis.reviewer_status == 'flagged'
+         and 'IO list' in (analysis.reviewer_notes or ''))
+
+    # ===== SIZE CAP REJECTION (unit-level) =====
+    print("\n=== Size Cap Enforcement ===")
+    too_big = make_zip({'big_file.txt': b'x' * 1024})
+    # Force a reject by bumping the limit envvar locally won't take effect after
+    # import, so we test the function path directly with a stub.
+    try:
+        # Create an oversized zip member by pretending the limit is tiny.
+        import bid_package_service
+        original = bid_package_service.MAX_PACKAGE_SIZE_BYTES
+        bid_package_service.MAX_PACKAGE_SIZE_BYTES = 10
+        too_big.seek(0)
+
+        class _Stream:
+            def __init__(self, b):
+                self.stream = b
+                self.filename = 'too_big.zip'
+        try:
+            ingest_zip_filelike(
+                project_id=project.id,
+                user_id=user.id,
+                file_storage=_Stream(too_big),
+                original_filename='too_big.zip',
+            )
+            raised = False
+        except BidPackageError:
+            raised = True
+        bid_package_service.MAX_PACKAGE_SIZE_BYTES = original
+    except Exception as exc:
+        raised = False
+        print(f"  unexpected: {exc}")
+    test("Size cap raises BidPackageError", raised)
+
+    # ===== SUMMARY =====
+    print(f"\n=== Results ===\n  Passed: {passed}\n  Failed: {failed}")
+    sys.exit(0 if failed == 0 else 1)

--- a/triage_analyzer.py
+++ b/triage_analyzer.py
@@ -1,0 +1,332 @@
+"""Per-document triage analysis using Claude Haiku 4.5.
+
+For each ``ProjectDocument`` belonging to a bid package, this module:
+
+1. Loads the document text via ``parse_document``.
+2. Detects scanned PDFs / OCR-needed cases and flags them without calling Claude.
+3. Calls Claude Haiku with a strict JSON-output prompt that returns
+   ``{trade, document_type, addendum_label, synopsis, key_entities, confidence}``.
+4. Validates the response against a small schema and persists a
+   ``DocumentAnalysis`` row.
+
+Costs roughly $0.001 per document at current Haiku 4.5 pricing for the
+~3-5k-character inputs typical of bid-package items.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from datetime import datetime, timezone
+
+import anthropic
+
+from config.settings import ANTHROPIC_API_KEY
+from context_retrieval import retrieve_context
+from document_parser import parse_document
+from models import DocumentAnalysis, EtgKnowledgeAsset, ProjectDocument, db
+
+
+# Cheap classifier for fast, low-cost triage. Override per-user via
+# ``User.llm_model`` if a power user wants Opus everywhere.
+DEFAULT_TRIAGE_MODEL = "claude-haiku-4-5-20251001"
+
+# Hard caps so a single weird document can't blow the budget.
+MAX_INPUT_CHARS = 16000  # text fed into the prompt
+MIN_TEXT_FOR_LLM = 200  # below this, we treat as "needs_review"
+MAX_OUTPUT_TOKENS = 800
+
+# Default trade and document-type values we accept. The taxonomy can be
+# overridden by editing the system-seeded EtgKnowledgeAsset rows in Settings.
+_FALLBACK_TRADES = {
+    "general", "electrical", "instrumentation", "automation_controls",
+    "process_mechanical", "piping_pid", "structural_civil", "hvac",
+    "building_automation", "networking_cybersecurity",
+    "validation_qualification", "commissioning", "safety", "project_management",
+}
+_FALLBACK_DOC_TYPES = {
+    "rfp_narrative", "specification", "datasheet", "drawing",
+    "sequence_of_operations", "io_list", "bill_of_materials", "schedule",
+    "addendum", "contract_legal", "submittal", "vendor_proposal",
+    "rfp_qa_log", "checklist", "report", "uncategorized",
+}
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def analyze_document(
+    document_id: str,
+    *,
+    api_key: str | None = None,
+    model: str | None = None,
+    vertical: str | None = None,
+) -> DocumentAnalysis:
+    """Run the full triage pass on a single document. Idempotent.
+
+    Returns the upserted ``DocumentAnalysis`` row regardless of outcome.
+    """
+    document = db.session.get(ProjectDocument, document_id)
+    if document is None:
+        raise ValueError(f"ProjectDocument {document_id} not found")
+
+    analysis = _get_or_create_analysis(document)
+    analysis.status = "analyzing"
+    analysis.error_message = ""
+    db.session.commit()
+
+    try:
+        text = _safe_parse(document.file_path)
+    except Exception as exc:
+        analysis.status = "failed"
+        analysis.error_message = f"Failed to extract text: {exc}"
+        analysis.analyzed_at = datetime.now(timezone.utc)
+        db.session.commit()
+        return analysis
+
+    analysis.text_length = len(text)
+
+    # Empty / scanned PDFs: flag and stop. The AE can re-run after OCR.
+    if len(text.strip()) < MIN_TEXT_FOR_LLM:
+        analysis.needs_ocr = document.file_path.lower().endswith(".pdf")
+        analysis.status = "needs_review"
+        analysis.synopsis = (
+            "Insufficient text was extractable from this document. "
+            "It may be a scanned PDF, an empty file, or in an unsupported format. "
+            "Please review manually."
+        )
+        analysis.confidence = 0.0
+        analysis.analyzed_at = datetime.now(timezone.utc)
+        db.session.commit()
+        return analysis
+
+    chosen_model = model or DEFAULT_TRIAGE_MODEL
+
+    prompt_text = _build_user_prompt(document, text, vertical=vertical)
+    system_prompt = _build_system_prompt(vertical=vertical, user_id=document.project.user_id)
+
+    try:
+        result = _call_claude(
+            api_key=api_key,
+            model=chosen_model,
+            system_prompt=system_prompt,
+            user_prompt=prompt_text,
+        )
+    except anthropic.APIError as exc:
+        analysis.status = "failed"
+        analysis.error_message = f"AI API error: {exc}"
+        analysis.analyzed_at = datetime.now(timezone.utc)
+        analysis.llm_model = chosen_model
+        db.session.commit()
+        return analysis
+    except Exception as exc:
+        analysis.status = "failed"
+        analysis.error_message = f"AI call failed: {exc}"
+        analysis.analyzed_at = datetime.now(timezone.utc)
+        analysis.llm_model = chosen_model
+        db.session.commit()
+        return analysis
+
+    parsed = _parse_response(result)
+    if parsed is None:
+        analysis.status = "failed"
+        analysis.error_message = "Could not parse JSON from AI response"
+        analysis.analyzed_at = datetime.now(timezone.utc)
+        analysis.llm_model = chosen_model
+        db.session.commit()
+        return analysis
+
+    analysis.trade = _normalize_trade(parsed.get("trade", ""))
+    analysis.document_type_detected = _normalize_doc_type(parsed.get("document_type", ""))
+    analysis.addendum_label = (parsed.get("addendum_label") or "").strip()[:80]
+    analysis.synopsis = (parsed.get("synopsis") or "").strip()
+    analysis.key_entities = json.dumps(parsed.get("key_entities") or {}, ensure_ascii=False)
+    try:
+        analysis.confidence = float(parsed.get("confidence", 0.5))
+    except (TypeError, ValueError):
+        analysis.confidence = 0.5
+
+    analysis.status = "analyzed"
+    analysis.llm_model = chosen_model
+    analysis.analyzed_at = datetime.now(timezone.utc)
+    db.session.commit()
+    return analysis
+
+
+# ---------------------------------------------------------------------------
+# Internals
+# ---------------------------------------------------------------------------
+
+
+def _get_or_create_analysis(document: ProjectDocument) -> DocumentAnalysis:
+    analysis = DocumentAnalysis.query.filter_by(document_id=document.id).first()
+    if analysis is not None:
+        return analysis
+    analysis = DocumentAnalysis(
+        document_id=document.id,
+        project_id=document.project_id,
+        bid_package_id=document.bid_package_id,
+    )
+    db.session.add(analysis)
+    db.session.flush()
+    return analysis
+
+
+def _safe_parse(path: str) -> str:
+    try:
+        return parse_document(path) or ""
+    except ValueError:
+        # Unsupported extension (e.g., .dwg). Treat as empty so the
+        # needs_review branch fires.
+        return ""
+
+
+def _build_system_prompt(*, vertical: str | None, user_id: str | None) -> str:
+    taxonomy = retrieve_context(
+        ["taxonomy"],
+        user_id=user_id,
+        max_chars=2000,
+    )
+    company = retrieve_context(
+        ["company_profile", "capabilities"],
+        user_id=user_id,
+        vertical=vertical,
+        max_chars=3000,
+    )
+
+    body = """You are the ETG Pre-Proposal Triage Analyst. Your job is to read a single document from a customer bid package and produce a short structured classification used by Application Engineers to navigate the package.
+
+Be factual and concise. Do NOT promote, market, or speculate. If you cannot tell, choose the closest match and lower your confidence score.
+
+Return a single JSON object only. No prose before or after. No markdown fences. Schema:
+
+{
+  "trade": "<one of the trade keys>",
+  "document_type": "<one of the document_type keys>",
+  "addendum_label": "<e.g. 'Base', 'Addendum 1', 'Rev B', or empty string>",
+  "synopsis": "<25-35 word factual summary in plain English>",
+  "key_entities": {
+    "systems": [<short string identifiers like 'H1', 'S1', 'BMS-01'>],
+    "io_count": <integer if explicitly stated, else null>,
+    "instrument_count": <integer if explicitly stated, else null>,
+    "valve_count": <integer if explicitly stated, else null>,
+    "notes": "<brief free-text about anything else worth flagging>"
+  },
+  "confidence": <float 0.0..1.0>
+}
+"""
+
+    if taxonomy:
+        body += "\n## Taxonomy (use only these values)\n" + taxonomy
+    if company:
+        body += "\n\n## ETG Context (background — do not echo)\n" + company
+
+    return body
+
+
+def _build_user_prompt(document: ProjectDocument, text: str, *, vertical: str | None) -> str:
+    truncated = text[:MAX_INPUT_CHARS]
+    note = "" if len(text) <= MAX_INPUT_CHARS else "\n\n[Document text was truncated for length.]"
+    vertical_line = f"Vertical (hint): {vertical}\n" if vertical else ""
+    return f"""Document filename: {document.original_filename}
+Relative path in package: {document.relative_path or document.original_filename}
+Detected size: {document.file_size} bytes
+{vertical_line}
+--- BEGIN DOCUMENT TEXT ---
+{truncated}{note}
+--- END DOCUMENT TEXT ---
+
+Return the JSON object now."""
+
+
+def _call_claude(
+    *,
+    api_key: str | None,
+    model: str,
+    system_prompt: str,
+    user_prompt: str,
+) -> str:
+    key = api_key or ANTHROPIC_API_KEY
+    if not key:
+        raise RuntimeError("No Anthropic API key configured")
+
+    client = anthropic.Anthropic(api_key=key, timeout=60.0, max_retries=2)
+    msg = client.messages.create(
+        model=model,
+        max_tokens=MAX_OUTPUT_TOKENS,
+        system=system_prompt,
+        messages=[{"role": "user", "content": user_prompt}],
+    )
+    parts = []
+    for block in msg.content:
+        if getattr(block, "type", None) == "text":
+            parts.append(block.text)
+    return "".join(parts).strip()
+
+
+_JSON_BLOCK_RE = re.compile(r"\{.*\}", re.DOTALL)
+
+
+def _parse_response(raw: str) -> dict | None:
+    if not raw:
+        return None
+    candidate = raw.strip()
+    if candidate.startswith("```"):
+        # Strip code fences if the model insisted on them.
+        candidate = candidate.strip("`")
+        candidate = re.sub(r"^json\n", "", candidate, flags=re.IGNORECASE)
+    try:
+        return json.loads(candidate)
+    except json.JSONDecodeError:
+        pass
+    match = _JSON_BLOCK_RE.search(candidate)
+    if not match:
+        return None
+    try:
+        return json.loads(match.group(0))
+    except json.JSONDecodeError:
+        return None
+
+
+def _allowed_set(section: str, key: str, fallback: set[str]) -> set[str]:
+    """Pull the live taxonomy from EtgKnowledgeAsset; fall back to the seed list."""
+    asset = EtgKnowledgeAsset.query.filter_by(
+        user_id=None, section="taxonomy", title=key
+    ).first()
+    if asset is None or not asset.content_md:
+        return set(fallback)
+    items = set()
+    for line in asset.content_md.splitlines():
+        s = line.strip().lstrip("-* ").strip()
+        if s:
+            items.add(s)
+    return items or set(fallback)
+
+
+def _normalize_trade(value: str) -> str:
+    raw = (value or "").strip().lower().replace(" ", "_")
+    if not raw:
+        return "general"
+    allowed = _allowed_set("taxonomy", "Trades", _FALLBACK_TRADES)
+    if raw in allowed:
+        return raw
+    # Soft match: take the first allowed value that appears as a substring.
+    for cand in allowed:
+        if cand in raw or raw in cand:
+            return cand
+    return "general"
+
+
+def _normalize_doc_type(value: str) -> str:
+    raw = (value or "").strip().lower().replace(" ", "_")
+    if not raw:
+        return "uncategorized"
+    allowed = _allowed_set("taxonomy", "Document Types", _FALLBACK_DOC_TYPES)
+    if raw in allowed:
+        return raw
+    for cand in allowed:
+        if cand in raw or raw in cand:
+            return cand
+    return "uncategorized"

--- a/triage_worker.py
+++ b/triage_worker.py
@@ -1,0 +1,262 @@
+"""Background worker for pre-proposal triage jobs.
+
+A simple SQLite-backed job runner. Designed to run as a sidecar container
+next to the Flask app via docker-compose. Polls the ``triage_jobs`` table
+for ``pending`` rows, claims them with an atomic UPDATE, executes the
+matching handler, and updates status. No Redis. No Celery.
+
+Usage:
+    python triage_worker.py            # poll forever
+    python triage_worker.py --once     # process the queue once and exit
+    python triage_worker.py --drain    # alias for --once
+
+The worker is safe to run as multiple replicas: claims use ``WHERE
+status='pending'`` plus a per-row uuid stamp before commit so two workers
+can't claim the same job. SQLite + WAL handles this fine for the throughput
+we expect (dozens of jobs/min, not thousands).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import signal
+import sys
+import time
+from datetime import datetime, timezone
+
+# ``app`` is imported solely for the Flask app context (DB engine setup).
+# Importing here keeps the worker process self-contained.
+from app import app  # noqa: E402  (intentional after imports)
+from models import (  # noqa: E402
+    BidPackage,
+    DocumentAnalysis,
+    Project,
+    ProjectDocument,
+    TriageJob,
+    User,
+    db,
+)
+
+LOG = logging.getLogger("triage_worker")
+logging.basicConfig(
+    level=os.getenv("TRIAGE_WORKER_LOG_LEVEL", "INFO"),
+    format="%(asctime)s %(levelname)s [%(name)s] %(message)s",
+)
+
+
+POLL_INTERVAL_SECONDS = float(os.getenv("TRIAGE_WORKER_POLL_INTERVAL", "3"))
+HEARTBEAT_SECONDS = 30
+
+
+_should_stop = False
+
+
+def _signal_stop(signum, frame):  # pragma: no cover - process-level concern
+    global _should_stop
+    LOG.info("Stop signal %s received; finishing current job and exiting", signum)
+    _should_stop = True
+
+
+# ---------------------------------------------------------------------------
+# Public entry points
+# ---------------------------------------------------------------------------
+
+
+def enqueue_analyze_document(
+    document_id: str,
+    *,
+    project_id: str | None = None,
+    bid_package_id: str | None = None,
+    user_id: str | None = None,
+) -> TriageJob:
+    """Insert a job to analyze a single document. Returns the inserted row."""
+    job = TriageJob(
+        job_type="analyze_document",
+        project_id=project_id,
+        bid_package_id=bid_package_id,
+        document_id=document_id,
+        user_id=user_id,
+        payload="{}",
+    )
+    db.session.add(job)
+    db.session.commit()
+    return job
+
+
+def enqueue_package_analysis(
+    package: BidPackage,
+    *,
+    user_id: str | None = None,
+) -> int:
+    """Enqueue an analyze_document job for every doc in a package. Returns count."""
+    docs = ProjectDocument.query.filter_by(bid_package_id=package.id).all()
+    count = 0
+    for doc in docs:
+        # Skip docs that already have a successful analysis.
+        if doc.analysis is not None and doc.analysis.status in {"analyzed", "needs_review"}:
+            continue
+        enqueue_analyze_document(
+            doc.id,
+            project_id=package.project_id,
+            bid_package_id=package.id,
+            user_id=user_id,
+        )
+        count += 1
+    return count
+
+
+def run_once() -> int:
+    """Process all currently-pending jobs once. Returns the count handled."""
+    handled = 0
+    with app.app_context():
+        while True:
+            job = _claim_next_job()
+            if job is None:
+                break
+            _process(job)
+            handled += 1
+    return handled
+
+
+def run_forever() -> None:
+    """Long-running poll loop."""
+    LOG.info("Triage worker starting; poll=%.1fs", POLL_INTERVAL_SECONDS)
+    signal.signal(signal.SIGINT, _signal_stop)
+    signal.signal(signal.SIGTERM, _signal_stop)
+    while not _should_stop:
+        try:
+            handled = run_once()
+        except Exception:  # pragma: no cover - keep the worker alive
+            LOG.exception("Worker loop crashed; will retry")
+            handled = 0
+        if handled == 0:
+            time.sleep(POLL_INTERVAL_SECONDS)
+
+
+# ---------------------------------------------------------------------------
+# Internals
+# ---------------------------------------------------------------------------
+
+
+def _claim_next_job() -> TriageJob | None:
+    """Atomically pick the oldest pending job and mark it ``running``.
+
+    Uses a stamp-and-check pattern compatible with SQLite (no SELECT FOR
+    UPDATE). The worker writes its own pid into ``error_message`` as a
+    claim marker, commits, then re-reads. If two workers race, only one
+    will see its own pid; the other re-polls.
+    """
+    pending = (
+        TriageJob.query.filter_by(status="pending")
+        .order_by(TriageJob.created_at.asc())
+        .first()
+    )
+    if pending is None:
+        return None
+    stamp = f"claim:{os.getpid()}:{datetime.now(timezone.utc).isoformat()}"
+    pending.status = "running"
+    pending.attempts = (pending.attempts or 0) + 1
+    pending.started_at = datetime.now(timezone.utc)
+    pending.heartbeat_at = pending.started_at
+    pending.error_message = stamp
+    db.session.commit()
+
+    # Re-read to confirm we actually own it.
+    fresh = db.session.get(TriageJob, pending.id)
+    if fresh is None or fresh.error_message != stamp or fresh.status != "running":
+        return None
+    fresh.error_message = ""
+    db.session.commit()
+    return fresh
+
+
+def _process(job: TriageJob) -> None:
+    LOG.info("Processing job %s type=%s attempt=%d", job.id, job.job_type, job.attempts)
+    try:
+        if job.job_type == "analyze_document":
+            _handle_analyze_document(job)
+        else:
+            raise ValueError(f"Unknown job type: {job.job_type}")
+        job.status = "done"
+        job.error_message = ""
+        job.finished_at = datetime.now(timezone.utc)
+        db.session.commit()
+    except Exception as exc:
+        LOG.exception("Job %s failed", job.id)
+        job.error_message = f"{exc.__class__.__name__}: {exc}"[:1000]
+        if (job.attempts or 0) >= (job.max_attempts or 1):
+            job.status = "failed"
+            job.finished_at = datetime.now(timezone.utc)
+        else:
+            job.status = "pending"  # retry on next poll
+        db.session.commit()
+
+
+def _handle_analyze_document(job: TriageJob) -> None:
+    if not job.document_id:
+        raise ValueError("analyze_document job requires document_id")
+
+    # Late import: the analyzer pulls in anthropic, which is a heavy import.
+    # Doing it here keeps the worker bootstrap lean if a job dies before
+    # ever hitting an analyze.
+    from triage_analyzer import analyze_document
+
+    api_key = None
+    model = None
+    if job.user_id:
+        user = db.session.get(User, job.user_id)
+        if user:
+            api_key = user.api_key_encrypted or None
+
+    vertical = None
+    if job.project_id:
+        project = db.session.get(Project, job.project_id)
+        if project:
+            vertical = project.vertical
+
+    payload = _safe_json(job.payload)
+    model = payload.get("model")  # optional override
+
+    analysis: DocumentAnalysis = analyze_document(
+        job.document_id,
+        api_key=api_key,
+        model=model,
+        vertical=vertical,
+    )
+    if analysis.status == "failed":
+        # Surface analyzer errors to the job row so the UI can show them.
+        raise RuntimeError(analysis.error_message or "Analysis failed")
+
+
+def _safe_json(raw: str | None) -> dict:
+    if not raw:
+        return {}
+    try:
+        return json.loads(raw)
+    except (TypeError, ValueError):
+        return {}
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def main() -> int:  # pragma: no cover - CLI wrapper
+    parser = argparse.ArgumentParser(description="ETG Proposal Manager triage worker")
+    parser.add_argument("--once", "--drain", action="store_true",
+                        help="Process the queue once and exit")
+    args = parser.parse_args()
+    if args.once:
+        handled = run_once()
+        LOG.info("Processed %d jobs", handled)
+        return 0
+    run_forever()
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/web_templates/bid_package_index.html
+++ b/web_templates/bid_package_index.html
@@ -1,0 +1,115 @@
+{% extends "base.html" %}
+
+{% block title %}Bid Package Index &mdash; {{ project.name }}{% endblock %}
+
+{% block content %}
+<section class="page-header">
+    <div class="page-header-row">
+        <div>
+            <h1>Bid Package Index</h1>
+            <p class="page-subtitle">{{ project.name }} &mdash; {{ package.original_filename or package.id }}</p>
+        </div>
+        <div class="header-actions">
+            <a href="{{ url_for('bid_package_landing', project_id=project.id) }}" class="btn btn-small btn-secondary">All Packages</a>
+            <a href="{{ url_for('bid_package_xlsx', project_id=project.id, package_id=package.id) }}" class="btn btn-small btn-secondary">Export XLSX</a>
+            <form method="post" action="{{ url_for('bid_package_analyze', project_id=project.id, package_id=package.id) }}" class="inline-form">
+                <button type="submit" class="btn btn-small btn-primary">Run Analysis</button>
+            </form>
+        </div>
+    </div>
+</section>
+
+<div class="card">
+    <div class="form-row">
+        <div class="form-group">
+            <strong>{{ rows | length }}</strong> documents &middot;
+            <strong>{{ analyzed_count }}</strong> analyzed
+            {% if pending_jobs %}&middot; <span class="badge">{{ pending_jobs }} in queue</span>{% endif %}
+        </div>
+        <div class="form-group">
+            {% if package.duplicate_count %}<span class="form-hint">{{ package.duplicate_count }} duplicate(s) skipped at upload.</span>{% endif %}
+            {% if package.skipped_count %}<span class="form-hint">{{ package.skipped_count }} file(s) skipped (errors).</span>{% endif %}
+        </div>
+    </div>
+
+    {% if trade_counts %}
+    <p class="form-hint"><strong>By trade:</strong>
+        {% for t, n in trade_counts %}<span class="badge">{{ t }} &times; {{ n }}</span>{% if not loop.last %} {% endif %}{% endfor %}
+    </p>
+    {% endif %}
+    {% if type_counts %}
+    <p class="form-hint"><strong>By document type:</strong>
+        {% for t, n in type_counts %}<span class="badge">{{ t }} &times; {{ n }}</span>{% if not loop.last %} {% endif %}{% endfor %}
+    </p>
+    {% endif %}
+</div>
+
+<div class="card">
+    <h2>Documents</h2>
+    {% if rows %}
+    <input type="text" id="bid-filter" placeholder="Filter by filename, trade, or synopsis..." class="input-small" style="width:100%; margin-bottom:8px;">
+    <table class="mini-table" id="bid-table">
+        <thead>
+            <tr>
+                <th>Path / File</th>
+                <th>Trade</th>
+                <th>Type</th>
+                <th>Addendum</th>
+                <th>Synopsis</th>
+                <th>Status</th>
+                <th>Review</th>
+            </tr>
+        </thead>
+        <tbody>
+        {% for r in rows %}
+        <tr data-search="{{ (r.relative_path ~ ' ' ~ r.name ~ ' ' ~ r.trade ~ ' ' ~ r.document_type ~ ' ' ~ r.synopsis) | lower }}">
+            <td>
+                <div><strong>{{ r.name }}</strong></div>
+                {% if r.relative_path and r.relative_path != r.name %}<div class="form-hint">{{ r.relative_path }}</div>{% endif %}
+                {% if r.needs_ocr %}<span class="badge badge-status-flagged">needs OCR</span>{% endif %}
+            </td>
+            <td>{% if r.trade %}<span class="badge">{{ r.trade }}</span>{% else %}&mdash;{% endif %}</td>
+            <td>{% if r.document_type %}<span class="badge">{{ r.document_type }}</span>{% else %}&mdash;{% endif %}</td>
+            <td>{{ r.addendum_label or '&mdash;' | safe }}</td>
+            <td>{{ r.synopsis or '&mdash;' | safe }}</td>
+            <td>
+                <span class="badge badge-status-{{ r.status }}">{{ r.status }}</span>
+                {% if r.confidence %}<div class="form-hint">conf {{ "%.0f"|format(r.confidence * 100) }}%</div>{% endif %}
+            </td>
+            <td>
+                <form method="post" action="{{ url_for('bid_package_set_review', project_id=project.id, package_id=package.id, document_id=r.id) }}" class="inline-form">
+                    <select name="reviewer_status" class="status-select">
+                        <option value="unreviewed" {% if r.reviewer_status == 'unreviewed' %}selected{% endif %}>Unreviewed</option>
+                        <option value="reviewed" {% if r.reviewer_status == 'reviewed' %}selected{% endif %}>Reviewed</option>
+                        <option value="flagged" {% if r.reviewer_status == 'flagged' %}selected{% endif %}>Flagged</option>
+                    </select>
+                    <button type="submit" class="btn btn-small btn-secondary">Save</button>
+                </form>
+            </td>
+        </tr>
+        {% endfor %}
+        </tbody>
+    </table>
+    {% else %}
+    <p class="empty-hint">No documents in this package.</p>
+    {% endif %}
+</div>
+{% endblock %}
+
+{% block scripts %}
+<script>
+(function(){
+    var filter = document.getElementById('bid-filter');
+    var table = document.getElementById('bid-table');
+    if (!filter || !table) return;
+    filter.addEventListener('input', function(){
+        var q = filter.value.trim().toLowerCase();
+        var rows = table.querySelectorAll('tbody tr');
+        for (var i = 0; i < rows.length; i++) {
+            var hay = rows[i].getAttribute('data-search') || '';
+            rows[i].style.display = (!q || hay.indexOf(q) !== -1) ? '' : 'none';
+        }
+    });
+})();
+</script>
+{% endblock %}

--- a/web_templates/bid_package_landing.html
+++ b/web_templates/bid_package_landing.html
@@ -1,0 +1,81 @@
+{% extends "base.html" %}
+
+{% block title %}Bid Package &mdash; {{ project.name }}{% endblock %}
+
+{% block content %}
+<section class="page-header">
+    <div class="page-header-row">
+        <div>
+            <h1>Pre-Proposal Triage</h1>
+            <p class="page-subtitle">{{ project.name }} &mdash; {{ project.client_name or 'No client specified' }}</p>
+        </div>
+        <div class="header-actions">
+            <a href="{{ url_for('project_upload', project_id=project.id) }}" class="btn btn-small btn-secondary">Back to Project</a>
+        </div>
+    </div>
+</section>
+
+<div class="card">
+    <h2>Upload a Bid Package</h2>
+    <p class="card-desc">Drop a zip archive of all documents the customer sent (RFP, addenda, drawings, datasheets, etc.). Each file becomes searchable in the index, and the AI will classify and summarize every document so AEs can find what matters fast.</p>
+
+    <form method="post" action="{{ url_for('bid_package_upload', project_id=project.id) }}" enctype="multipart/form-data">
+        <div class="form-row">
+            <div class="form-group" style="flex:2">
+                <label>Bid Package (.zip)</label>
+                <input type="file" name="bid_package_zip" accept=".zip" required>
+            </div>
+            <div class="form-group" style="flex:1; align-self:flex-end;">
+                <button type="submit" class="btn btn-primary">Upload &amp; Ingest</button>
+            </div>
+        </div>
+        <p class="form-hint">Per-package size limit: 2 GB. Files: 500 max. Only document file types are kept (.pdf, .docx, .xlsx, .txt, .md, .csv, .dwg, .dxf).</p>
+    </form>
+</div>
+
+{% if packages %}
+<div class="card">
+    <h2>Bid Packages ({{ packages | length }})</h2>
+    <table class="mini-table">
+        <thead>
+            <tr>
+                <th>Uploaded</th>
+                <th>Source</th>
+                <th>Files</th>
+                <th>Duplicates</th>
+                <th>Size</th>
+                <th>Status</th>
+                <th></th>
+            </tr>
+        </thead>
+        <tbody>
+        {% for p in packages %}
+        <tr>
+            <td>{{ p.ingested_at.strftime('%Y-%m-%d %H:%M') }}</td>
+            <td>{{ p.original_filename or p.source }}</td>
+            <td>{{ p.file_count }}</td>
+            <td>{{ p.duplicate_count }}</td>
+            <td>
+                {% if p.total_size_bytes >= 1073741824 %}{{ "%.2f"|format(p.total_size_bytes / 1073741824) }} GB
+                {% elif p.total_size_bytes >= 1048576 %}{{ "%.1f"|format(p.total_size_bytes / 1048576) }} MB
+                {% elif p.total_size_bytes >= 1024 %}{{ "%.0f"|format(p.total_size_bytes / 1024) }} KB
+                {% else %}{{ p.total_size_bytes }} B{% endif %}
+            </td>
+            <td><span class="badge badge-status-{{ p.status }}">{{ p.status }}</span></td>
+            <td>
+                <a href="{{ url_for('bid_package_index', project_id=project.id, package_id=p.id) }}" class="btn btn-small btn-secondary">Open Index</a>
+            </td>
+        </tr>
+        {% if p.error_message %}
+        <tr><td colspan="7"><span class="form-hint" style="color:#b91c1c;">Error: {{ p.error_message }}</span></td></tr>
+        {% endif %}
+        {% endfor %}
+        </tbody>
+    </table>
+</div>
+{% else %}
+<div class="card">
+    <p class="empty-hint">No bid packages uploaded yet. Upload a zip above to start the triage.</p>
+</div>
+{% endif %}
+{% endblock %}

--- a/web_templates/etg_knowledge.html
+++ b/web_templates/etg_knowledge.html
@@ -1,0 +1,140 @@
+{% extends "base.html" %}
+
+{% block title %}ETG Knowledge Base &mdash; {{ app_name }}{% endblock %}
+
+{% block content %}
+<section class="page-header">
+    <div class="page-header-row">
+        <div>
+            <h1>ETG Knowledge Base</h1>
+            <p class="page-subtitle">Structured company context the AI pulls into every triage and proposal prompt. Add what makes ETG &mdash; not the customer&rsquo;s package &mdash; sound like ETG.</p>
+        </div>
+        <div class="header-actions">
+            <a href="{{ url_for('settings') }}" class="btn btn-small btn-secondary">Back to Settings</a>
+        </div>
+    </div>
+</section>
+
+<div class="card">
+    <h2>Add Knowledge Asset</h2>
+    <form method="post" action="{{ url_for('etg_knowledge_add') }}">
+        <div class="form-row">
+            <div class="form-group">
+                <label>Section</label>
+                <select name="section" required>
+                    {% for key, label in sections %}
+                    <option value="{{ key }}">{{ label }}</option>
+                    {% endfor %}
+                </select>
+            </div>
+            <div class="form-group" style="flex:2">
+                <label>Title</label>
+                <input type="text" name="title" placeholder="e.g., Life Science Cleanroom Capability Statement" required>
+            </div>
+            <div class="form-group">
+                <label>Vertical</label>
+                <select name="vertical">
+                    <option value="">All verticals</option>
+                    {% for k, v in verticals.items() %}
+                    <option value="{{ k }}">{{ v.label }}</option>
+                    {% endfor %}
+                </select>
+            </div>
+        </div>
+        <div class="form-group">
+            <label>Content (Markdown)</label>
+            <textarea name="content_md" rows="6" placeholder="Plain Markdown describing the asset. Keep it factual and specific to ETG &mdash; the AI uses this as authoritative context."></textarea>
+        </div>
+        <div class="form-row">
+            <div class="form-group">
+                <label>Tags (comma-separated)</label>
+                <input type="text" name="tags" placeholder="cleanroom, gmp, validation">
+            </div>
+            {% if can_edit_global %}
+            <div class="form-group" style="align-self:flex-end;">
+                <label class="checkbox-inline">
+                    <input type="checkbox" name="is_global"> Make this asset visible to the whole company
+                </label>
+            </div>
+            {% endif %}
+        </div>
+        <button type="submit" class="btn btn-primary">Add to Knowledge Base</button>
+    </form>
+</div>
+
+{% for key, label in sections %}
+<div class="card" id="{{ key }}">
+    <h2>{{ label }}</h2>
+    {% set assets = grouped.get(key, []) %}
+    {% if assets %}
+    <table class="mini-table">
+        <thead>
+            <tr>
+                <th>Title</th>
+                <th>Vertical</th>
+                <th>Tags</th>
+                <th>Source</th>
+                <th>Active</th>
+                <th>Preview</th>
+                <th></th>
+            </tr>
+        </thead>
+        <tbody>
+        {% for a in assets %}
+        <tr>
+            <td>
+                <strong>{{ a.title }}</strong>
+                {% if a.user_id is none %}<span class="badge">global</span>{% endif %}
+            </td>
+            <td>{{ a.vertical or '&mdash;' | safe }}</td>
+            <td>{{ a.tags or '&mdash;' | safe }}</td>
+            <td>{{ a.source }}</td>
+            <td>{% if a.is_active %}<span class="badge badge-status-active">yes</span>{% else %}<span class="badge">no</span>{% endif %}</td>
+            <td class="td-desc">{{ (a.content_md or '')[:160] }}{% if a.content_md and a.content_md|length > 160 %}&hellip;{% endif %}</td>
+            <td>
+                <details>
+                    <summary class="btn btn-small btn-secondary">Edit</summary>
+                    <form method="post" action="{{ url_for('etg_knowledge_edit', asset_id=a.id) }}" style="margin-top:8px;">
+                        <div class="form-group">
+                            <label>Title</label>
+                            <input type="text" name="title" value="{{ a.title }}">
+                        </div>
+                        <div class="form-group">
+                            <label>Vertical</label>
+                            <select name="vertical">
+                                <option value="" {% if not a.vertical %}selected{% endif %}>All verticals</option>
+                                {% for k, v in verticals.items() %}
+                                <option value="{{ k }}" {% if a.vertical == k %}selected{% endif %}>{{ v.label }}</option>
+                                {% endfor %}
+                            </select>
+                        </div>
+                        <div class="form-group">
+                            <label>Tags</label>
+                            <input type="text" name="tags" value="{{ a.tags or '' }}">
+                        </div>
+                        <div class="form-group">
+                            <label>Content</label>
+                            <textarea name="content_md" rows="6">{{ a.content_md or '' }}</textarea>
+                        </div>
+                        <label class="checkbox-inline">
+                            <input type="checkbox" name="is_active" {% if a.is_active %}checked{% endif %}> Active
+                        </label>
+                        <div style="margin-top:8px;">
+                            <button type="submit" class="btn btn-small btn-primary">Save</button>
+                        </div>
+                    </form>
+                    <form method="post" action="{{ url_for('etg_knowledge_delete', asset_id=a.id) }}" style="margin-top:6px;">
+                        <button type="submit" class="btn btn-small btn-danger" onclick="return confirm('Delete this asset?')">Delete</button>
+                    </form>
+                </details>
+            </td>
+        </tr>
+        {% endfor %}
+        </tbody>
+    </table>
+    {% else %}
+    <p class="empty-hint">No assets in this section yet.</p>
+    {% endif %}
+</div>
+{% endfor %}
+{% endblock %}

--- a/web_templates/project_upload.html
+++ b/web_templates/project_upload.html
@@ -16,6 +16,7 @@
             </p>
         </div>
         <div class="header-actions">
+            <a href="{{ url_for('bid_package_landing', project_id=project.id) }}" class="btn btn-small btn-secondary">Bid Package Triage</a>
             <a href="{{ url_for('clarification_register', project_id=project.id) }}" class="btn btn-small btn-secondary">Clarifications</a>
             <form method="post" action="{{ url_for('update_project_status', project_id=project.id) }}" class="inline-form">
                 <input type="text" name="dollar_amount" placeholder="Dollar amount" value="{{ project.dollar_amount if project.dollar_amount else '' }}" class="input-small">

--- a/web_templates/settings.html
+++ b/web_templates/settings.html
@@ -232,6 +232,7 @@
     <div class="card">
         <h2>Company Standards & Posture</h2>
         <p class="card-desc">Define your company's standard content that the AI will automatically include in proposals: mission statement, certifications, past performance, safety record, quality standards, etc.</p>
+        <p class="form-hint">Looking for richer, structured ETG context? Try the new <a href="{{ url_for('etg_knowledge_index') }}">ETG Knowledge Base</a> &mdash; same auto-inject, plus capabilities, tech stack, exclusions, and per-vertical scope.</p>
 
         <form method="post" action="{{ url_for('add_company_standard') }}" enctype="multipart/form-data" class="upload-inline">
             <div class="form-row">


### PR DESCRIPTION
Adds the front-end triage stage AEs need before proposal generation:

- Folder/zip bid-package ingestion (bid_package_service.py + new routes)
  with SHA-256 dedup, per-package size caps, and zip-slip protection
- Per-document analysis pipeline using Claude Haiku 4.5 for fast/cheap
  classification (trade, document type, addendum label, ~25-word synopsis,
  key entities) with JSON-schema validation and graceful needs_review for
  scanned PDFs
- SQLite-backed background worker (triage_worker.py) added as a sidecar
  service in docker-compose so 100+ document packages can run
  asynchronously without blocking the gunicorn workers
- Structured ETG knowledge base (EtgKnowledgeAsset) replacing the looser
  CompanyStandard model. System-seeded taxonomy and per-vertical expected-
  document checklists. CompanyStandard CRUD now mirrors writes into the
  knowledge base; the proposal generator reads from it as the single source
- New Settings → ETG Knowledge UI for editing assets per section/vertical
- Bid package landing + sortable filterable index UI with XLSX export
- 38 new tests in test_features.py style; existing 246 tests still pass