### PR TITLE
Fix 5 P0 release blockers in the core proposal generation chain

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,14 @@ WORKDIR /app
 # IPv6 precedence makes glibc return A records first so httpx connects over v4.
 RUN printf '\nprecedence ::ffff:0:0/96  100\n' >> /etc/gai.conf
 
+# Tesseract powers OCR of scanned (image-only) PDF uploads. Optional at
+# runtime — the app degrades gracefully if it's absent — but installed here so
+# hosted deployments get it. (PDF page rendering uses the self-contained
+# pypdfium2 wheel, so no poppler/system renderer is needed.)
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends tesseract-ocr \
+    && rm -rf /var/lib/apt/lists/*
+
 # Install dependencies
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt

--- a/app.py
+++ b/app.py
@@ -683,6 +683,24 @@ def _send_stored_file(path, **kwargs):
     return send_file(str(path), **kwargs)
 
 
+def _proposal_markdown(proposal) -> str:
+    """Canonical proposal content for reading.
+
+    The latest ProposalVersion row is the source of truth — it survives
+    redeploys and multi-instance deployments where the generated file on local
+    disk may be missing or stale. The generated .md file (pulled from object
+    storage if needed) is only a fallback for legacy proposals without a
+    version row. Returns "" when no content can be found."""
+    version = latest_version(proposal.id)
+    if version and (version.markdown_content or "").strip():
+        return version.markdown_content
+    md_path = GENERATED_DIR / proposal.md_file
+    storage.ensure_local(md_path)
+    if md_path.exists():
+        return md_path.read_text(encoding="utf-8")
+    return ""
+
+
 def _logo_docx_kwargs(user, company_name_override: str = "") -> dict:
     """Build the logo-related kwargs passed into markdown_to_docx so they
     respect the user's branding preferences."""
@@ -2784,6 +2802,38 @@ def project_generate(project_id):
     return redirect(url_for("job_status_page", job_id=job.id))
 
 
+def _load_org_templates(org_id, vertical) -> dict | None:
+    """The org's uploaded templates for a generation, keyed by template_type.
+
+    Priority per type: user upload for the vertical, then the admin-set company
+    default for the vertical, then the 'general' equivalents — so an org that
+    only uploaded a General template still gets it when the RFP resolves to a
+    specific vertical. Files are pulled from object storage when the local copy
+    is missing."""
+    tiers = [
+        {"vertical": vertical, "is_company_default": False},
+        {"vertical": vertical, "is_company_default": True},
+    ]
+    if vertical != "general":
+        tiers += [
+            {"vertical": "general", "is_company_default": False},
+            {"vertical": "general", "is_company_default": True},
+        ]
+    picked = {}
+    for tier in tiers:
+        for t in UserVerticalTemplate.query.filter_by(org_id=org_id, **tier).all():
+            if t.template_type not in picked:
+                picked[t.template_type] = t
+    templates = {}
+    for ttype, t in picked.items():
+        try:
+            storage.ensure_local(t.file_path)
+            templates[ttype] = parse_document(t.file_path)
+        except Exception:
+            continue
+    return templates or None
+
+
 def _perform_generation(project_id, user, vertical, output_format, cost_options, set_progress):
     """Gather posture context and run proposal generation. Returns a dict with
     a 'redirect' key. Runs inside a background job (no request context)."""
@@ -2804,6 +2854,17 @@ def _perform_generation(project_id, user, vertical, output_format, cost_options,
             continue
     if not combined_text.strip():
         raise RuntimeError("Could not extract text from the uploaded documents.")
+
+    # Resolve "auto" BEFORE loading templates. The template queries below match
+    # on the vertical key, so resolving after them (as before) meant the
+    # default Auto-Detect path silently skipped every org-uploaded template.
+    scope = ProjectScope.query.filter_by(project_id=project_id).first()
+    if vertical == "auto":
+        if scope and scope.status == "approved" and scope.vertical:
+            vertical = scope.vertical
+        else:
+            from document_parser import detect_vertical
+            vertical = detect_vertical(combined_text)
 
     org_id = user.org_id
     include_staff_types = cost_options.get("include_staff_types")
@@ -2865,35 +2926,12 @@ def _perform_generation(project_id, user, vertical, output_format, cost_options,
         rate_sheet_data = {}
         for sheet in active_sheets:
             try:
+                storage.ensure_local(sheet.file_path)
                 rate_sheet_data[sheet.sheet_type] = parse_rate_sheet(sheet.file_path)
             except Exception:
                 continue
 
-    # Auto-select templates: user custom first, then company defaults as fallback
-    user_templates = None
-    user_tmpls = UserVerticalTemplate.query.filter_by(
-        org_id=org_id, vertical=vertical, is_company_default=False
-    ).all()
-    if user_tmpls:
-        user_templates = {}
-        for t in user_tmpls:
-            try:
-                user_templates[t.template_type] = parse_document(t.file_path)
-            except Exception:
-                continue
-
-    # Fall back to company defaults for any missing template types
-    co_tmpls = UserVerticalTemplate.query.filter_by(
-        vertical=vertical, is_company_default=True, org_id=org_id
-    ).all()
-    if co_tmpls:
-        user_templates = user_templates or {}
-        for t in co_tmpls:
-            if t.template_type not in user_templates:
-                try:
-                    user_templates[t.template_type] = parse_document(t.file_path)
-                except Exception:
-                    continue
+    user_templates = _load_org_templates(org_id, vertical)
 
     # Load past corrections for AI learning
     past_corrections = ProposalCorrection.query.filter_by(
@@ -2924,15 +2962,23 @@ def _perform_generation(project_id, user, vertical, output_format, cost_options,
 
     # Human-approved Scope of Work guides the draft when present
     approved_scope_items = None
-    scope = ProjectScope.query.filter_by(project_id=project_id).first()
     if scope and scope.status == "approved":
         included = ScopeItem.query.filter_by(scope_id=scope.id, status="included").order_by(
             ScopeItem.sort_order, ScopeItem.created_at
         ).all()
         if included:
             approved_scope_items = [i.item_text for i in included]
-            if vertical == "auto" and scope.vertical:
-                vertical = scope.vertical
+
+    # Feed previously answered clarification questions back to the AI so a
+    # regeneration actually incorporates the user's answers (and doesn't
+    # re-ask them).
+    answered_rows = ProposalQuestion.query.filter_by(
+        project_id=project_id, status="answered"
+    ).order_by(ProposalQuestion.answered_at).all()
+    answered_questions = [
+        {"question": r.question, "answer": r.answer}
+        for r in answered_rows if (r.answer or "").strip()
+    ]
 
     set_progress("drafting", "Claude is drafting your proposal…")
     result = generate_proposal(
@@ -2943,6 +2989,7 @@ def _perform_generation(project_id, user, vertical, output_format, cost_options,
         company_name=user.company_name,
         user_api_key=decrypt_api_key(user.api_key_encrypted) or None,
         user_model=user.llm_model or None,
+        answered_questions=answered_questions or None,
         cost_options=cost_options,
         staff_roles_data=staff_roles_data,
         equipment_data=equipment_data,
@@ -2951,14 +2998,29 @@ def _perform_generation(project_id, user, vertical, output_format, cost_options,
         company_standards=company_standards_data,
         approved_scope=approved_scope_items,
         request_type=project.request_type or "",
+        include_global_boilerplate=SELF_HOSTED,
     )
 
     billing_record_generation(org_id)
 
-    # If the agent needs clarification, record questions and stop here
+    # If the agent needs clarification, record the questions and stop — but
+    # only for questions we haven't asked before on this project. Re-asked
+    # duplicates (already answered/skipped) must not re-open the loop or
+    # duplicate register rows; if nothing is genuinely new, fall through and
+    # save the proposal.
+    new_questions = []
     if result.get("questions"):
+        already_asked = {
+            (q.question or "").strip().lower()
+            for q in ProposalQuestion.query.filter_by(project_id=project_id).all()
+        }
+        new_questions = [
+            q for q in result["questions"]
+            if (q.get("question") or "").strip().lower() not in already_asked
+        ]
+    if new_questions:
         set_progress("questions", "Clarification questions detected…")
-        for q in result["questions"]:
+        for q in new_questions:
             db.session.add(ProposalQuestion(
                 project_id=project_id,
                 question=q["question"],
@@ -2980,7 +3042,7 @@ def _perform_generation(project_id, user, vertical, output_format, cost_options,
         project.clarification_sub_status = "clarification_pending"
         db.session.commit()
         _log_activity_for(user, "proposal_questions",
-                          f"{len(result['questions'])} clarification question(s)", project_id)
+                          f"{len(new_questions)} clarification question(s)", project_id)
         return {"redirect": url_for("project_questions", project_id=project_id)}
 
     set_progress("saving", "Formatting and saving your proposal…")
@@ -3117,6 +3179,7 @@ def _project_rfp_text(project_id: str) -> str:
     combined = ""
     for doc in rfp_docs:
         try:
+            storage.ensure_local(doc.file_path)
             text = parse_document(doc.file_path)
             combined += f"\n\n--- Document: {doc.original_filename} ---\n\n{text}"
         except Exception:
@@ -3541,12 +3604,11 @@ def view_proposal(proposal_id):
         abort(404)
     project = db.session.get(Project, proposal.project_id)
 
-    md_path = GENERATED_DIR / proposal.md_file
-    if not md_path.exists():
-        flash("Proposal file not found.", "error")
+    proposal_md = _proposal_markdown(proposal)
+    if not proposal_md:
+        flash("Proposal content not found.", "error")
         return redirect(url_for("dashboard"))
 
-    proposal_md = md_path.read_text(encoding="utf-8")
     action_items = re.findall(r"\[ACTION REQUIRED:\s*(.+?)\]", proposal_md)
 
     # Version history for the viewer dropdown
@@ -4001,9 +4063,11 @@ def edit_proposal(proposal_id):
         )
         db.session.add(version)
 
-        # Update the markdown file on disk
+        # Update the markdown file on disk (and mirror to object storage so the
+        # edit survives redeploys / reaches other instances)
         md_path = GENERATED_DIR / proposal.md_file
         md_path.write_text(new_content, encoding="utf-8")
+        storage.sync_up(md_path)
 
         # Regenerate DOCX from new content
         if proposal.docx_file:
@@ -4014,6 +4078,7 @@ def edit_proposal(proposal_id):
                 str(docx_path),
                 **_logo_docx_kwargs(_brand_user),
             )
+            storage.sync_up(docx_path)
 
         # Update action items count
         action_items = re.findall(r"\[ACTION REQUIRED:\s*(.+?)\]", new_content)
@@ -4024,9 +4089,8 @@ def edit_proposal(proposal_id):
         flash(f"Proposal saved as version {next_version}.", "success")
         return redirect(url_for("edit_proposal", proposal_id=proposal_id))
 
-    # Load current content
-    md_path = GENERATED_DIR / proposal.md_file
-    current_content = md_path.read_text(encoding="utf-8") if md_path.exists() else ""
+    # Load current content (DB version first; file fallback)
+    current_content = _proposal_markdown(proposal)
 
     # Load version history
     versions = ProposalVersion.query.filter_by(proposal_id=proposal_id).order_by(
@@ -4162,9 +4226,10 @@ def restore_version(proposal_id, version_id):
     )
     db.session.add(restored)
 
-    # Update file on disk
+    # Update file on disk (mirrored to object storage)
     md_path = GENERATED_DIR / proposal.md_file
     md_path.write_text(version.markdown_content, encoding="utf-8")
+    storage.sync_up(md_path)
 
     if proposal.docx_file:
         docx_path = GENERATED_DIR / proposal.docx_file
@@ -4174,6 +4239,7 @@ def restore_version(proposal_id, version_id):
             str(docx_path),
             **_logo_docx_kwargs(_brand_user),
         )
+        storage.sync_up(docx_path)
 
     db.session.commit()
     _log_activity("proposal_restore", f"Restored proposal to v{version.version_number}", project.id)
@@ -4498,8 +4564,7 @@ def proposal_review_page(proposal_id):
         return redirect(url_for("view_proposal", proposal_id=proposal_id))
 
     version = latest_version(proposal_id)
-    md_path = GENERATED_DIR / proposal.md_file
-    proposal_md = md_path.read_text(encoding="utf-8") if md_path.exists() else ""
+    proposal_md = _proposal_markdown(proposal)
     proposal_html = htmlsafe.sanitize(md.markdown(proposal_md, extensions=["tables", "fenced_code"]))
 
     # My pending/existing revision requests on this proposal
@@ -4822,12 +4887,16 @@ def apply_feedback(proposal_id):
     db.session.add(new_version)
     db.session.flush()
 
-    # Write the new markdown/docx to disk
+    # Write the new markdown/docx to disk (mirrored to object storage)
     md_path = GENERATED_DIR / proposal.md_file
     md_path.write_text(result["revised_markdown"], encoding="utf-8")
+    storage.sync_up(md_path)
     if proposal.docx_file:
         docx_path = GENERATED_DIR / proposal.docx_file
-        markdown_to_docx(result["revised_markdown"], str(docx_path))
+        _brand_user = project.owner or current_user
+        markdown_to_docx(result["revised_markdown"], str(docx_path),
+                         **_logo_docx_kwargs(_brand_user))
+        storage.sync_up(docx_path)
 
     # Update action items count
     proposal.action_items_count = len(
@@ -5063,7 +5132,17 @@ def customer_portal(token):
         share.last_viewed_at = now
         db.session.commit()
 
-    version = latest_version(proposal.id)
+    # Render the version that was SHARED, not whatever is latest — internal
+    # edits made after submission must not silently change what the customer
+    # sees (or what they accepted). Falls back to latest only for legacy
+    # shares created before version pinning.
+    version = None
+    if share.version_number:
+        version = ProposalVersion.query.filter_by(
+            proposal_id=proposal.id, version_number=share.version_number
+        ).first()
+    if version is None:
+        version = latest_version(proposal.id)
     md_text = version.markdown_content if version else ""
     # Strip internal-only markers from the customer-facing view
     # DOTALL/IGNORECASE so multi-line internal markers are also stripped and can't
@@ -6222,7 +6301,7 @@ def download_document(doc_id):
     project = db.session.get(Project, doc.project_id)
     if not _can_access_project(project):
         abort(404)
-    return send_file(doc.file_path, as_attachment=True, download_name=doc.original_filename)
+    return _send_stored_file(doc.file_path, as_attachment=True, download_name=doc.original_filename)
 
 
 @app.route("/documents/<doc_id>/preview")
@@ -6235,7 +6314,7 @@ def preview_document(doc_id):
     project = db.session.get(Project, doc.project_id)
     if not _can_access_project(project):
         abort(404)
-    return send_file(doc.file_path, as_attachment=False)
+    return _send_stored_file(doc.file_path, as_attachment=False)
 
 
 @app.route("/documents/<doc_id>/tags", methods=["POST"])
@@ -6388,6 +6467,7 @@ def bulk_download_documents():
     tmp = tempfile.NamedTemporaryFile(delete=False, suffix=".zip")
     with zipfile.ZipFile(tmp.name, "w", zipfile.ZIP_DEFLATED) as zf:
         for doc in docs:
+            storage.ensure_local(doc.file_path)
             src = Path(doc.file_path)
             if src.exists():
                 zf.write(str(src), doc.original_filename)
@@ -7126,13 +7206,11 @@ def proposal_reviews(proposal_id):
     approvals = sum(1 for c in comments if c.comment_type == "approval")
 
     # Extract section headings from proposal for dropdown
-    md_path = GENERATED_DIR / proposal.md_file
     sections = []
-    if md_path.exists():
-        for line in md_path.read_text(encoding="utf-8").splitlines():
-            stripped = line.strip()
-            if stripped.startswith("## ") or stripped.startswith("### "):
-                sections.append(stripped)
+    for line in _proposal_markdown(proposal).splitlines():
+        stripped = line.strip()
+        if stripped.startswith("## ") or stripped.startswith("### "):
+            sections.append(stripped)
 
     users = _org_users_query().order_by(User.display_name).all()
 
@@ -7407,24 +7485,22 @@ def addendum_analysis(project_id):
     for doc in rfp_docs:
         if doc.id != addendum_doc_id:
             try:
+                storage.ensure_local(doc.file_path)
                 original_rfp_text += parse_document(doc.file_path) + "\n"
             except Exception:
                 continue
 
     # Get addendum text
     try:
+        storage.ensure_local(addendum_doc.file_path)
         addendum_text = parse_document(addendum_doc.file_path)
     except Exception:
         flash("Could not parse addendum document.", "error")
         return redirect(url_for("project_upload", project_id=project_id))
 
-    # Get current proposal
+    # Get current proposal (DB version first; file fallback)
     proposal = Proposal.query.filter_by(project_id=project_id).order_by(Proposal.generated_at.desc()).first()
-    current_md = ""
-    if proposal:
-        md_path = GENERATED_DIR / proposal.md_file
-        if md_path.exists():
-            current_md = md_path.read_text(encoding="utf-8")
+    current_md = _proposal_markdown(proposal) if proposal else ""
 
     if not current_md:
         flash("No existing proposal to analyze against.", "error")
@@ -7489,15 +7565,16 @@ def regenerate_proposal_section(proposal_id):
         flash("Section heading and clarification info are required.", "error")
         return redirect(url_for("edit_proposal", proposal_id=proposal_id))
 
-    # Get current proposal content
+    # Get current proposal content (DB version first; file fallback)
     md_path = GENERATED_DIR / proposal.md_file
-    current_md = md_path.read_text(encoding="utf-8") if md_path.exists() else ""
+    current_md = _proposal_markdown(proposal)
 
     # Get original RFP text for context
     rfp_docs = ProjectDocument.query.filter_by(project_id=proposal.project_id, file_type="rfp").all()
     rfp_text = ""
     for doc in rfp_docs:
         try:
+            storage.ensure_local(doc.file_path)
             rfp_text += parse_document(doc.file_path) + "\n"
         except Exception:
             continue
@@ -7540,11 +7617,15 @@ def regenerate_proposal_section(proposal_id):
         )
         db.session.add(version)
 
-        # Update file on disk
+        # Update file on disk (mirrored to object storage)
         md_path.write_text(updated_md, encoding="utf-8")
+        storage.sync_up(md_path)
         if proposal.docx_file:
             docx_path = GENERATED_DIR / proposal.docx_file
-            markdown_to_docx(updated_md, str(docx_path))
+            _brand_user = project.owner or current_user
+            markdown_to_docx(updated_md, str(docx_path),
+                             **_logo_docx_kwargs(_brand_user))
+            storage.sync_up(docx_path)
 
         # Update action items count
         action_items = re.findall(r"\[ACTION REQUIRED:\s*(.+?)\]", updated_md)

--- a/app.py
+++ b/app.py
@@ -262,6 +262,25 @@ def localtime_filter(dt, style="dt"):
     )
 
 
+@app.template_filter("money_compact")
+def money_compact_filter(value):
+    """Humanized currency: $850 · $45k · $1.2M — replaces the old always-in-
+    millions formatting that showed a $45,000 deal as \"$0.0M\"."""
+    try:
+        v = float(value or 0)
+    except (TypeError, ValueError):
+        v = 0.0
+    sign = "-" if v < 0 else ""
+    v = abs(v)
+    if v >= 1_000_000:
+        return f"{sign}${v / 1_000_000:,.1f}M"
+    if v >= 10_000:
+        return f"{sign}${v / 1_000:,.0f}k"
+    if v >= 1_000:
+        return f"{sign}${v / 1_000:,.1f}k"
+    return f"{sign}${v:,.0f}"
+
+
 @app.context_processor
 def inject_branding():
     return dict(
@@ -648,6 +667,15 @@ def _setup_progress(user) -> dict:
             "done": bool(org and org.logo_path),
         },
         {
+            "key": "team",
+            "title": "Invite your team",
+            "desc": "Teammates draft, review, and approve together.",
+            "endpoint": "admin_panel",
+            "anchor": "",
+            "done": (User.query.filter_by(org_id=user.org_id).count() > 1
+                     or OrgInvitation.query.filter_by(org_id=user.org_id).count() > 0),
+        },
+        {
             "key": "template",
             "title": "Upload a proposal template",
             "desc": "The AI follows your structure when drafting.",
@@ -705,6 +733,9 @@ def _setup_progress(user) -> dict:
             "done": Proposal.query.join(Project).filter(Project.user_id == user.id).count() > 0,
         },
     ]
+    # Only admins can invite — don't show members a to-do they can't act on.
+    if not user.is_admin:
+        steps = [s for s in steps if s["key"] != "team"]
     done = sum(1 for s in steps if s["done"])
     return {
         "steps": steps,
@@ -888,6 +919,12 @@ def _process_and_save_logo(file, owner_id: str) -> tuple[str, str, int]:
 # Auth routes
 # ---------------------------------------------------------------------------
 
+def _email_matches(email: str):
+    """Exact case-insensitive email predicate. (ilike allowed `%`/`_` wildcards
+    from user input into email lookups — usable to probe or spam resets.)"""
+    return db.func.lower(User.email) == (email or "").strip().lower()
+
+
 def _valid_invitation(token: str) -> OrgInvitation | None:
     if not token:
         return None
@@ -909,13 +946,13 @@ def accept_invite(token):
         flash("This invitation link is invalid, expired, or already used.", "error")
         return redirect(url_for("signup"))
     org = db.session.get(Organization, inv.org_id)
-    return render_template("signup.html", invitation=inv, invite_org=org)
+    return render_template("signup.html", invitation=inv, invite_org=org, form=None)
 
 
 @app.route("/signup", methods=["GET", "POST"])
 def signup():
     if request.method == "GET":
-        return render_template("signup.html", invitation=None, invite_org=None)
+        return render_template("signup.html", invitation=None, invite_org=None, form=None)
 
     if not app.testing and _signup_rate_limited(request.remote_addr or "?"):
         flash("Too many new accounts from this network. Please try again later.", "error")
@@ -933,23 +970,28 @@ def signup():
         flash("This invitation link is invalid, expired, or already used.", "error")
         return redirect(url_for("signup"))
 
+    def _signup_again(message):
+        # Re-render with the typed values preserved — the old redirect pattern
+        # wiped the whole form on every validation error.
+        flash(message, "error")
+        invite_org = db.session.get(Organization, invitation.org_id) if invitation else None
+        return render_template("signup.html", invitation=invitation,
+                               invite_org=invite_org, form=request.form)
+
     if not username or not email or not password:
-        flash("All fields are required.", "error")
-        return redirect(url_for("signup"))
+        return _signup_again("All fields are required.")
 
     if len(password) < 8:
-        flash("Password must be at least 8 characters.", "error")
-        return redirect(url_for("signup"))
+        return _signup_again("Password must be at least 8 characters.")
 
     if User.query.filter_by(username=username).first():
-        flash("Username already taken.", "error")
-        return redirect(url_for("signup"))
+        return _signup_again("Username already taken.")
 
     # Email must be globally unique (case-insensitive) — duplicates break
     # password reset and verification. For invited signups validate the
     # INVITED address, since that's what the account is bound to.
     effective_email = invitation.email if invitation else email
-    if User.query.filter(User.email.ilike(effective_email)).first():
+    if User.query.filter(_email_matches(effective_email)).first():
         flash("An account with that email address already exists. "
               "Sign in instead, or use the password reset if you've forgotten it.", "error")
         return redirect(url_for("login"))
@@ -1019,25 +1061,30 @@ def login():
     if current_user.is_authenticated:
         return redirect(url_for("dashboard"))
     if request.method == "GET":
-        return render_template("login.html")
+        return render_template("login.html", ident="")
 
     username = request.form.get("username", "").strip()
     password = request.form.get("password", "")
 
+    def _login_again(message):
+        flash(message, "error")
+        return render_template("login.html", ident=username)
+
     rl_key = f"{request.remote_addr}:{username.lower()}"
     if _login_rate_limited(rl_key):
-        flash("Too many login attempts. Please wait a few minutes and try again.", "error")
-        return redirect(url_for("login"))
+        return _login_again("Too many login attempts. Please wait a few minutes and try again.")
 
-    user = User.query.filter_by(username=username).first()
+    # Sign in with either username or email (emails are unique)
+    user = User.query.filter(
+        db.or_(User.username == username, _email_matches(username))
+    ).first()
 
     # Cross-worker, per-account lockout (survives multiple gunicorn workers and
     # catches password spraying against one account regardless of source IP).
     now = datetime.now(timezone.utc)
     if user and user.lockout_until and _aware(user.lockout_until) > now:
-        flash("This account is temporarily locked after too many failed attempts. "
-              "Please wait a few minutes and try again.", "error")
-        return redirect(url_for("login"))
+        return _login_again("This account is temporarily locked after too many "
+                            "failed attempts. Please wait a few minutes and try again.")
 
     if not user or not user.check_password(password):
         _record_login_attempt(rl_key)
@@ -1047,14 +1094,12 @@ def login():
                 user.lockout_until = now + timedelta(seconds=_ACCOUNT_LOCK_SECONDS)
                 user.failed_login_count = 0
             db.session.commit()
-        flash("Invalid username or password.", "error")
-        return redirect(url_for("login"))
+        return _login_again("Invalid username or password.")
 
     # Deactivated members can't sign in (checked after password verification so
     # probing can't distinguish "wrong password" from "deactivated").
     if user.is_active is False:
-        flash("This account has been deactivated. Contact your workspace admin.", "error")
-        return redirect(url_for("login"))
+        return _login_again("This account has been deactivated. Contact your workspace admin.")
 
     _LOGIN_ATTEMPTS.pop(rl_key, None)
     if user.failed_login_count or user.lockout_until:
@@ -1155,7 +1200,7 @@ def forgot_password():
     email = request.form.get("email", "").strip().lower()
     # Always show the same message to avoid leaking which emails exist
     generic = "If an account exists for that email, a reset link has been sent."
-    user = User.query.filter(User.email.ilike(email)).first() if email else None
+    user = User.query.filter(_email_matches(email)).first() if email else None
     if user:
         raw = _issue_token(user, "reset", hours=2)
         link = url_for("reset_password", token=raw, _external=True)
@@ -1623,31 +1668,37 @@ def dashboard():
     # --- Part 3: Review widgets ----------------------------------------------
 
     # "Pending My Review" — proposals where I'm an assigned reviewer and I
-    # haven't yet recorded a decision on the latest version.
+    # haven't yet recorded a decision on the latest version. Bulk-loaded
+    # (previously 4 queries per review assignment).
     my_reviews_pending: list[dict] = []
     my_assignments = ProposalReviewer.query.filter_by(user_id=current_user.id).all()
+    rev_prop_ids = [r.proposal_id for r in my_assignments]
+    rev_props = {p.id: p for p in Proposal.query.filter(
+        Proposal.id.in_(rev_prop_ids)).all()} if rev_prop_ids else {}
+    rev_versions = _latest_versions_for(list(rev_props))
+    decided = {
+        (a.proposal_id, a.version_id)
+        for a in ProposalApproval.query.filter(
+            ProposalApproval.proposal_id.in_(rev_prop_ids),
+            ProposalApproval.user_id == current_user.id).all()
+    } if rev_prop_ids else set()
+    rev_projects = {p.id: p for p in Project.query.filter(Project.id.in_(
+        [pr.project_id for pr in rev_props.values()])).all()} if rev_props else {}
     for r in my_assignments:
-        prop = db.session.get(Proposal, r.proposal_id)
-        if not prop:
+        prop = rev_props.get(r.proposal_id)
+        if not prop or prop.review_status not in ("in_review", "revision_requested"):
             continue
-        if prop.review_status not in ("in_review", "revision_requested"):
+        version = rev_versions.get(prop.id)
+        if not version or (prop.id, version.id) in decided:
             continue
-        version = latest_version(prop.id)
-        if not version:
-            continue
-        decision = ProposalApproval.query.filter_by(
-            proposal_id=prop.id, version_id=version.id, user_id=current_user.id
-        ).first()
-        if decision is not None:
-            continue
-        proj = db.session.get(Project, prop.project_id)
+        proj = rev_projects.get(prop.project_id)
         my_reviews_pending.append({
             "proposal": prop,
             "project": proj,
             "reviewer": r,
             "version_number": version.version_number,
             "deadline": r.deadline,
-            "overdue": bool(r.deadline) and r.deadline < datetime.now(timezone.utc),
+            "overdue": bool(r.deadline) and _aware(r.deadline) < datetime.now(timezone.utc),
         })
 
     # "Out for Review" — proposals I own that are currently in_review /
@@ -1659,16 +1710,19 @@ def dashboard():
                 Proposal.review_status.in_(("in_review", "revision_requested", "internally_approved")))
         .all()
     )
+    ofr_projects = {p.id: p for p in Project.query.filter(Project.id.in_(
+        [pr.project_id for pr in owned_props])).all()} if owned_props else {}
+    ofr_pending = _counts_by(
+        RevisionRequest.proposal_id, RevisionRequest.id,
+        RevisionRequest.proposal_id.in_([pr.id for pr in owned_props]),
+        RevisionRequest.status == "pending") if owned_props else {}
     for prop in owned_props:
         state = approval_state(prop)
-        proj = db.session.get(Project, prop.project_id)
         out_for_review.append({
             "proposal": prop,
-            "project": proj,
+            "project": ofr_projects.get(prop.project_id),
             "state": state,
-            "pending_req_count": RevisionRequest.query.filter_by(
-                proposal_id=prop.id, status="pending"
-            ).count(),
+            "pending_req_count": ofr_pending.get(prop.id, 0),
         })
 
     # "Awaiting Customer Response" — proposals I own that are out to customer
@@ -1678,10 +1732,12 @@ def dashboard():
                 Proposal.review_status.in_(("submitted_to_customer", "customer_feedback")))
         .all()
     )
-    awaiting_customer_items = []
-    for prop in awaiting_customer:
-        proj = db.session.get(Project, prop.project_id)
-        awaiting_customer_items.append({"proposal": prop, "project": proj})
+    ac_projects = {p.id: p for p in Project.query.filter(Project.id.in_(
+        [pr.project_id for pr in awaiting_customer])).all()} if awaiting_customer else {}
+    awaiting_customer_items = [
+        {"proposal": prop, "project": ac_projects.get(prop.project_id)}
+        for prop in awaiting_customer
+    ]
 
     # --- "Pick up where you left off" focus list -----------------------------
     focus_items = []
@@ -1798,6 +1854,24 @@ def _counts_by(column, count_of, *filters) -> dict:
     """Generic bulk counter: {key_column_value: count}."""
     q = db.session.query(column, db.func.count(count_of)).filter(*filters).group_by(column)
     return dict(q.all())
+
+
+def _latest_versions_for(proposal_ids) -> dict:
+    """{proposal_id: newest ProposalVersion} in one grouped query."""
+    if not proposal_ids:
+        return {}
+    from sqlalchemy import func as _f
+    latest = db.session.query(
+        ProposalVersion.proposal_id,
+        _f.max(ProposalVersion.version_number).label("maxv"),
+    ).filter(ProposalVersion.proposal_id.in_(proposal_ids)).group_by(
+        ProposalVersion.proposal_id
+    ).subquery()
+    rows = ProposalVersion.query.join(latest, db.and_(
+        ProposalVersion.proposal_id == latest.c.proposal_id,
+        ProposalVersion.version_number == latest.c.maxv,
+    )).all()
+    return {v.proposal_id: v for v in rows}
 
 
 def _build_proposal_rows():
@@ -2122,7 +2196,7 @@ def settings():
         new_email = request.form.get("email", current_user.email).strip()
         if new_email and new_email.lower() != (current_user.email or "").lower():
             clash = User.query.filter(
-                User.email.ilike(new_email), User.id != current_user.id
+                _email_matches(new_email), User.id != current_user.id
             ).first()
             if clash:
                 flash("That email address is already in use by another account.", "error")
@@ -2753,6 +2827,31 @@ def add_equipment_item():
     return redirect(url_for("posture") + "#equipment")
 
 
+@app.route("/settings/edit-equipment-item/<item_id>", methods=["POST"])
+@login_required
+def edit_equipment_item(item_id):
+    """Inline edit — rates were previously delete-and-retype only."""
+    item = db.session.get(EquipmentItem, item_id)
+    if not item or item.org_id != current_user.org_id:
+        abort(404)
+    item.item_name = request.form.get("item_name", item.item_name).strip() or item.item_name
+    item.category = request.form.get("eq_category", item.category).strip()
+    item.part_number = request.form.get("part_number", item.part_number).strip()
+    item.manufacturer = request.form.get("manufacturer", item.manufacturer).strip()
+    item.unit = request.form.get("unit", item.unit).strip() or "each"
+    try:
+        cost = request.form.get("unit_cost", "").replace(",", "").replace("$", "")
+        if cost:
+            item.unit_cost = max(float(cost), 0.0)
+    except ValueError:
+        flash("Invalid cost format.", "error")
+        return redirect(url_for("posture") + "#equipment")
+    db.session.commit()
+    _log_activity("equipment_edit", f"Updated equipment: {item.item_name}")
+    flash(f"Equipment item '{item.item_name}' updated.", "success")
+    return redirect(url_for("posture") + "#equipment")
+
+
 @app.route("/settings/delete-equipment-item/<item_id>", methods=["POST"])
 @login_required
 def delete_equipment_item(item_id):
@@ -2823,6 +2922,29 @@ def add_travel_rate():
     db.session.commit()
     _log_activity("travel_rate_add", f"Added travel rate: {expense_type} @ ${rate}/{unit}")
     flash(f"Travel rate '{expense_type}' added.", "success")
+    return redirect(url_for("posture") + "#travel")
+
+
+@app.route("/settings/edit-travel-rate/<rate_id>", methods=["POST"])
+@login_required
+def edit_travel_rate(rate_id):
+    """Inline edit — rates were previously delete-and-retype only."""
+    tr = db.session.get(TravelExpenseRate, rate_id)
+    if not tr or tr.org_id != current_user.org_id:
+        abort(404)
+    tr.expense_type = request.form.get("expense_type", tr.expense_type).strip() or tr.expense_type
+    tr.unit = request.form.get("travel_unit", tr.unit).strip() or tr.unit
+    tr.description = request.form.get("travel_description", tr.description).strip()
+    try:
+        rate = request.form.get("travel_rate", "").replace(",", "").replace("$", "")
+        if rate:
+            tr.rate = max(float(rate), 0.0)
+    except ValueError:
+        flash("Invalid rate format.", "error")
+        return redirect(url_for("posture") + "#travel")
+    db.session.commit()
+    _log_activity("travel_rate_edit", f"Updated travel rate: {tr.expense_type}")
+    flash(f"Travel rate '{tr.expense_type}' updated.", "success")
     return redirect(url_for("posture") + "#travel")
 
 
@@ -3018,8 +3140,15 @@ def project_upload(project_id):
     ).count()
     proposal_users = _org_proposal_users()
 
+    # Quota visibility: what a click on Generate costs and what's left
+    _quota_org = db.session.get(Organization, current_user.org_id) if current_user.org_id else None
+    gen_limit = billing.limits_for(_quota_org)["generations_per_month"]
+    gens_used = billing.generations_this_month(current_user.org_id)
+
     return render_template(
         "project_upload.html",
+        gen_limit=gen_limit,
+        gens_used=gens_used,
         project=project,
         documents=documents,
         verticals=VERTICALS,
@@ -3384,6 +3513,25 @@ def _perform_generation(project_id, user, vertical, output_format, cost_options,
     )
     storage.sync_up(docx_path)
 
+    # Honor the requested output format: pre-render the PDF for pdf/both so the
+    # download is instant. (The field was previously stored and ignored.)
+    pdf_filename = ""
+    if (output_format or "").lower() in ("pdf", "both"):
+        try:
+            pdf_filename = f"proposal_{job_slug}.pdf"
+            pdf_path = GENERATED_DIR / pdf_filename
+            _pdf_logo = None
+            if _gen_org and _gen_org.logo_path and _gen_org.logo_use_in_proposals:
+                storage.ensure_local(_gen_org.logo_path)
+                if Path(_gen_org.logo_path).exists():
+                    _pdf_logo = _gen_org.logo_path
+            markdown_to_pdf(result["proposal_markdown"], str(pdf_path),
+                            logo_path=_pdf_logo,
+                            company_name=(_gen_org.name if _gen_org else "") or "")
+            storage.sync_up(pdf_path)
+        except Exception:
+            pdf_filename = ""  # PDF failure never blocks the proposal
+
     project.vertical = result["vertical"]
     project.vertical_label = result["vertical_label"]
 
@@ -3398,7 +3546,7 @@ def _perform_generation(project_id, user, vertical, output_format, cost_options,
         action_items_count=len(result["action_items"]),
         md_file=md_filename,
         docx_file=docx_filename,
-        pdf_file="",
+        pdf_file=pdf_filename,
         review_status="draft",
     )
     db.session.add(proposal)
@@ -3421,6 +3569,14 @@ def _perform_generation(project_id, user, vertical, output_format, cost_options,
     db.session.commit()
     _log_activity_for(user, "proposal_generate",
                       f"Generated {result['vertical_label']} proposal", project_id)
+    # Notify the person who started the job too — they may have navigated away
+    # during the multi-minute generation.
+    _notify(
+        user.id, "proposal_generated",
+        f"Your proposal is ready: {project.name}",
+        f"{result['vertical_label']} draft generated (confidence {result['confidence_score']}%).",
+        link=f"/proposal/{proposal.id}",
+    )
     _notify_role_org(
         org_id, "sales", "proposal_generated",
         f"Proposal generated: {project.name}",
@@ -3466,6 +3622,24 @@ def job_status_page(job_id):
     if not job or job.user_id != current_user.id:
         abort(404)
     return render_template("job_status.html", job=job)
+
+
+@app.route("/jobs/<job_id>/cancel", methods=["POST"])
+@login_required
+def job_cancel(job_id):
+    """Cancel a queued/running job. A queued job never starts; a running one
+    finishes server-side but its result is discarded (see jobs._run_job) and it
+    stops counting toward quota."""
+    job = db.session.get(BackgroundJob, job_id)
+    if not job or job.user_id != current_user.id:
+        abort(404)
+    if job.status in ("queued", "running"):
+        job.status = "canceled"
+        job.error = "Canceled by user."
+        job.finished_at = datetime.now(timezone.utc)
+        db.session.commit()
+        flash("Job canceled.", "success")
+    return redirect(url_for("job_status_page", job_id=job_id))
 
 
 @app.route("/jobs/<job_id>/status.json")
@@ -3526,6 +3700,9 @@ def project_scope(project_id):
         ScopeItem.sort_order, ScopeItem.created_at
     ).all()
     included_count = sum(1 for i in items if i.status == "included")
+    ai_kept = sum(1 for i in items if i.source == "ai" and i.status == "included")
+    ai_struck = sum(1 for i in items if i.source == "ai" and i.status == "removed")
+    human_added = sum(1 for i in items if i.source == "human" and i.status == "included")
 
     latest_prop = (
         Proposal.query.filter_by(project_id=project_id)
@@ -3540,6 +3717,9 @@ def project_scope(project_id):
         scope=scope,
         items=items,
         included_count=included_count,
+        ai_kept=ai_kept,
+        ai_struck=ai_struck,
+        human_added=human_added,
         phases=phases,
         latest_prop=latest_prop,
     )
@@ -3662,6 +3842,35 @@ def _job_draft_scope(payload, job):
     def _sp(phase, message=""):
         jobs.set_progress(job, phase, message)
     return _perform_scope_draft(payload["project_id"], user, payload["vertical"], _sp)
+
+
+@app.route("/projects/<project_id>/scope/batch-update", methods=["POST"])
+@login_required
+def batch_update_scope(project_id):
+    """Apply all include/strike checkbox states in ONE submit — the old
+    per-checkbox form posted a full page reload for every single item."""
+    project = db.session.get(Project, project_id)
+    if not _can_access_project(project):
+        abort(404)
+    scope = ProjectScope.query.filter_by(project_id=project_id).first()
+    if not scope:
+        abort(404)
+
+    included_ids = set(request.form.getlist("included"))
+    changed = 0
+    for item in ScopeItem.query.filter_by(scope_id=scope.id).all():
+        new_status = "included" if item.id in included_ids else "removed"
+        if item.status != new_status:
+            item.status = new_status
+            changed += 1
+    if changed and scope.status == "approved":
+        scope.status = "draft"
+        flash("Scope modified — re-approve it before generating.", "success")
+    db.session.commit()
+    if changed:
+        _log_activity("scope_batch_update", f"Updated {changed} scope item(s)", project_id)
+    flash(f"{changed} item(s) updated." if changed else "No scope changes to save.", "success")
+    return redirect(url_for("project_scope", project_id=project_id))
 
 
 @app.route("/projects/<project_id>/scope/items/<item_id>/toggle", methods=["POST"])
@@ -5455,6 +5664,13 @@ def submit_to_customer(proposal_id):
         abort(404)
     project = db.session.get(Project, proposal.project_id)
 
+    # Send gate: open [ACTION REQUIRED] markers mean the document still has
+    # unresolved placeholders — require an explicit acknowledgement.
+    if (proposal.action_items_count or 0) > 0 and request.form.get("ack_action_items") != "1":
+        flash(f"{proposal.action_items_count} [ACTION REQUIRED] item(s) are still open. "
+              "Resolve them, or tick the acknowledgement box to send anyway.", "error")
+        return redirect(url_for("view_proposal", proposal_id=proposal_id))
+
     try:
         lifecycle_transition(
             proposal, "submitted_to_customer", current_user.id,
@@ -5492,6 +5708,12 @@ def create_share(proposal_id):
     if not proposal or not _is_proposal_owner(proposal):
         abort(404)
     project = db.session.get(Project, proposal.project_id)
+
+    # Same send gate as submit_to_customer: sharing IS sending.
+    if (proposal.action_items_count or 0) > 0 and request.form.get("ack_action_items") != "1":
+        flash(f"{proposal.action_items_count} [ACTION REQUIRED] item(s) are still open. "
+              "Resolve them, or tick the acknowledgement box to share anyway.", "error")
+        return redirect(url_for("view_proposal", proposal_id=proposal_id))
 
     customer_email = request.form.get("customer_email", "").strip()
     allow_comments = request.form.get("allow_comments", "1") == "1"
@@ -5588,6 +5810,25 @@ def _valid_share(token):
     return share
 
 
+def _share_version(share, proposal):
+    """The version pinned at share time (latest only for legacy unpinned shares)."""
+    version = None
+    if share.version_number:
+        version = ProposalVersion.query.filter_by(
+            proposal_id=proposal.id, version_number=share.version_number
+        ).first()
+    return version or latest_version(proposal.id)
+
+
+def _customer_markdown(version) -> str:
+    """Customer-facing markdown: internal-only markers stripped (DOTALL /
+    IGNORECASE so multi-line markers can't leak onto the public portal)."""
+    md_text = version.markdown_content if version else ""
+    md_text = re.sub(r"\[ACTION REQUIRED:.*?\]", "", md_text, flags=re.DOTALL | re.IGNORECASE)
+    md_text = re.sub(r"\[ASSUMED:.*?\]", "", md_text, flags=re.DOTALL | re.IGNORECASE)
+    return md_text
+
+
 @app.route("/p/<token>")
 def customer_portal(token):
     """Public, read-only branded proposal view for a customer. No login."""
@@ -5620,24 +5861,24 @@ def customer_portal(token):
         share.view_count = (share.view_count or 0) + 1
         share.last_viewed_at = now
         db.session.commit()
+        # Tell the owner the FIRST time the customer opens it (further views
+        # show on the share card without notification spam).
+        if share.view_count == 1 and project:
+            _notify(
+                project.user_id, "share_viewed",
+                f"Customer opened your proposal: {project.name}",
+                "First view of the share link just now.",
+                link=f"/proposal/{proposal.id}",
+            )
+            _notify_via_integrations(
+                project.org_id,
+                f"\U0001F440 Customer opened the proposal for *{project.name}*.")
 
     # Render the version that was SHARED, not whatever is latest — internal
     # edits made after submission must not silently change what the customer
-    # sees (or what they accepted). Falls back to latest only for legacy
-    # shares created before version pinning.
-    version = None
-    if share.version_number:
-        version = ProposalVersion.query.filter_by(
-            proposal_id=proposal.id, version_number=share.version_number
-        ).first()
-    if version is None:
-        version = latest_version(proposal.id)
-    md_text = version.markdown_content if version else ""
-    # Strip internal-only markers from the customer-facing view
-    # DOTALL/IGNORECASE so multi-line internal markers are also stripped and can't
-    # leak onto the public customer portal.
-    md_text = re.sub(r"\[ACTION REQUIRED:.*?\]", "", md_text, flags=re.DOTALL | re.IGNORECASE)
-    md_text = re.sub(r"\[ASSUMED:.*?\]", "", md_text, flags=re.DOTALL | re.IGNORECASE)
+    # sees (or what they accepted).
+    version = _share_version(share, proposal)
+    md_text = _customer_markdown(version)
     proposal_html = htmlsafe.sanitize(md.markdown(md_text, extensions=["tables", "fenced_code"]))
 
     company_name = (brand_org.name if brand_org else "") or ""
@@ -5670,6 +5911,40 @@ def portal_logo(token):
     if not Path(org.logo_path).exists():
         abort(404)
     return send_file(org.logo_path, mimetype="image/png")
+
+
+@app.route("/p/<token>/download.pdf")
+def portal_pdf(token):
+    """Customer-facing PDF of the SHARED (pinned) version, internal markers
+    stripped — the portal previously offered no way to save the document."""
+    share = _valid_share(token)
+    if not share:
+        abort(404)
+    proposal = db.session.get(Proposal, share.proposal_id)
+    project = db.session.get(Project, share.project_id)
+    version = _share_version(share, proposal)
+    md_text = _customer_markdown(version)
+    if not md_text.strip():
+        abort(404)
+
+    org = _org_for_project(project)
+    logo_path = None
+    company_name = ""
+    if org:
+        company_name = org.name or ""
+        if org.logo_path and org.logo_use_in_proposals:
+            storage.ensure_local(org.logo_path)
+            if Path(org.logo_path).exists():
+                logo_path = org.logo_path
+
+    pdf_path = GENERATED_DIR / f"portal_{share.id}.pdf"
+    try:
+        markdown_to_pdf(md_text, str(pdf_path), logo_path=logo_path, company_name=company_name)
+    except Exception:
+        abort(404)
+    safe_name = secure_filename(project.name if project else "proposal") or "proposal"
+    return send_file(str(pdf_path), mimetype="application/pdf",
+                     as_attachment=True, download_name=f"Proposal - {safe_name}.pdf")
 
 
 @app.route("/p/<token>/comment", methods=["POST"])
@@ -5726,12 +6001,21 @@ def portal_decision(token):
 
     decision = request.form.get("decision", "").strip()
     note = request.form.get("note", "").strip()
+    decider_name = request.form.get("decider_name", "").strip()[:200]
+    decider_title = request.form.get("decider_title", "").strip()[:200]
     if decision not in ("accepted", "declined"):
         flash("Invalid decision.", "error")
+        return redirect(url_for("customer_portal", token=token))
+    # Acceptance is a commitment — require a typed name as a lightweight
+    # signature record (declines may stay anonymous).
+    if decision == "accepted" and not decider_name:
+        flash("Please type your name to accept the proposal.", "error")
         return redirect(url_for("customer_portal", token=token))
 
     share.decision = decision
     share.decision_note = note
+    share.decided_by_name = decider_name
+    share.decided_by_title = decider_title
     share.decided_at = datetime.now(timezone.utc)
 
     try:
@@ -5749,8 +6033,10 @@ def portal_decision(token):
 
     if project:
         verb = "accepted" if decision == "accepted" else "declined"
+        by = f"by {decider_name}" + (f" ({decider_title})" if decider_title else "") if decider_name else ""
         _notify(project.user_id, "customer_decision",
-                f"Customer {verb}: {project.name}", note[:160],
+                f"Customer {verb}: {project.name}",
+                " ".join(x for x in (by, note[:140]) if x),
                 link=f"/proposal/{proposal.id}")
         _notify_via_integrations(project.org_id,
                                  f"{'✅' if decision=='accepted' else '❌'} Customer *{verb}* the proposal for *{project.name}*.")
@@ -6219,7 +6505,7 @@ def create_invitation():
         return redirect(url_for("admin_panel"))
 
     # Don't invite existing members
-    existing = _org_users_query().filter(User.email.ilike(email)).first()
+    existing = _org_users_query().filter(_email_matches(email)).first()
     if existing:
         flash(f"{email} is already a member of this workspace.", "error")
         return redirect(url_for("admin_panel"))
@@ -7836,7 +8122,10 @@ def update_clarification(item_id):
     ci.resolution_path = request.form.get("resolution_path", ci.resolution_path)
     ci.assigned_to_user_id = request.form.get("assigned_to_user_id") or ci.assigned_to_user_id
     ci.assigned_to_role = request.form.get("assigned_to_role", ci.assigned_to_role)
-    ci.confidence_impact = int(request.form.get("confidence_impact", ci.confidence_impact) or 0)
+    try:
+        ci.confidence_impact = int(request.form.get("confidence_impact", ci.confidence_impact) or 0)
+    except (TypeError, ValueError):
+        pass  # non-numeric input keeps the existing value instead of a 500
     db.session.commit()
 
     flash("Clarification updated.", "success")

--- a/app.py
+++ b/app.py
@@ -71,6 +71,7 @@ import jobs
 import ocr
 import proposal_agent
 import storage
+import twofa
 from document_parser import parse_document
 from models import (
     ActivityLog,
@@ -1129,10 +1130,77 @@ def login():
         user.failed_login_count = 0
         user.lockout_until = None
         db.session.commit()
+
+    # Two-factor gate: password was correct, but don't authenticate yet — stash
+    # a short-lived "pending" marker (NOT a login) and require the TOTP step.
+    if user.totp_enabled:
+        session["pending_2fa_user"] = user.id
+        session["pending_2fa_at"] = time.time()
+        return redirect(url_for("login_2fa"))
+
     session.permanent = True  # apply PERMANENT_SESSION_LIFETIME idle expiry
     login_user(user)
     _log_activity("login")
     return redirect(url_for("dashboard"))
+
+
+# Pending-2FA marker is valid for this long between password and code steps.
+_TWOFA_PENDING_TTL = 600
+
+
+def _complete_login(user):
+    session.pop("pending_2fa_user", None)
+    session.pop("pending_2fa_at", None)
+    session.permanent = True
+    login_user(user)
+    _log_activity("login")
+
+
+@app.route("/login/2fa", methods=["GET", "POST"])
+def login_2fa():
+    """Second login step for accounts with TOTP enabled. Reached only after a
+    correct password sets the pending marker — never a standalone entry point."""
+    if current_user.is_authenticated:
+        return redirect(url_for("dashboard"))
+    uid = session.get("pending_2fa_user")
+    started = session.get("pending_2fa_at", 0)
+    if not uid or (time.time() - float(started or 0)) > _TWOFA_PENDING_TTL:
+        session.pop("pending_2fa_user", None)
+        session.pop("pending_2fa_at", None)
+        flash("Your sign-in timed out. Please enter your password again.", "error")
+        return redirect(url_for("login"))
+    user = db.session.get(User, uid)
+    if not user or not user.totp_enabled or user.is_active is False:
+        session.pop("pending_2fa_user", None)
+        return redirect(url_for("login"))
+
+    if request.method == "GET":
+        return render_template("login_2fa.html")
+
+    rl_key = f"2fa:{request.remote_addr}:{uid}"
+    if _login_rate_limited(rl_key):
+        flash("Too many attempts. Please wait a few minutes and try again.", "error")
+        return render_template("login_2fa.html")
+
+    code = request.form.get("code", "").strip()
+    secret = crypto_util.decrypt(user.totp_secret_encrypted)
+    if twofa.verify_code(secret, code):
+        _complete_login(user)
+        return redirect(url_for("dashboard"))
+
+    # Fall back to a single-use backup code
+    ok, new_json = twofa.consume_backup_code(user.totp_backup_codes, code)
+    if ok:
+        user.totp_backup_codes = new_json
+        db.session.commit()
+        left = twofa.backup_codes_remaining(new_json)
+        _complete_login(user)
+        flash(f"Backup code accepted — {left} backup code(s) remaining.", "success")
+        return redirect(url_for("dashboard"))
+
+    _record_login_attempt(rl_key)
+    flash("Invalid code. Try again, or use one of your backup codes.", "error")
+    return render_template("login_2fa.html")
 
 
 # ---------------------------------------------------------------------------
@@ -2281,6 +2349,8 @@ def settings():
     return render_template(
         "settings.html",
         org=db.session.get(Organization, current_user.org_id) if current_user.org_id else None,
+        twofa_enabled=current_user.totp_enabled,
+        backup_codes_left=twofa.backup_codes_remaining(current_user.totp_backup_codes),
         rate_sheets=rate_sheets,
         user_templates=user_templates,
         staff_roles=staff_roles,
@@ -2315,6 +2385,91 @@ def change_password():
     _log_activity("password_change", "Changed account password")
     flash("Password updated.", "success")
     return redirect(url_for("settings"))
+
+
+# ---------------------------------------------------------------------------
+# Two-factor authentication (TOTP)
+# ---------------------------------------------------------------------------
+
+def _twofa_setup_page(secret):
+    """Render the enrollment page for a freshly generated (unconfirmed) secret."""
+    uri = twofa.provisioning_uri(secret, current_user.email or current_user.username, issuer=APP_NAME)
+    return render_template("twofa_setup.html", secret=secret, qr=twofa.qr_data_uri(uri))
+
+
+@app.route("/settings/2fa/start", methods=["POST"])
+@login_required
+def twofa_start():
+    """Generate an (unconfirmed) secret and show the QR to scan. 2FA is not
+    active until the user confirms with a code from their authenticator."""
+    if current_user.totp_enabled:
+        flash("Two-factor authentication is already on.", "error")
+        return redirect(url_for("settings"))
+    secret = twofa.new_secret()
+    current_user.totp_secret_encrypted = crypto_util.encrypt(secret)
+    db.session.commit()
+    return _twofa_setup_page(secret)
+
+
+@app.route("/settings/2fa/enable", methods=["POST"])
+@login_required
+def twofa_enable():
+    if current_user.totp_enabled:
+        return redirect(url_for("settings"))
+    secret = crypto_util.decrypt(current_user.totp_secret_encrypted)
+    if not secret:
+        flash("Start the two-factor setup first.", "error")
+        return redirect(url_for("settings"))
+    if not twofa.verify_code(secret, request.form.get("code", "")):
+        flash("That code didn't match — check your authenticator's clock and try again.", "error")
+        return _twofa_setup_page(secret)
+    plaintext, hashes = twofa.generate_backup_codes()
+    current_user.totp_enabled = True
+    current_user.totp_backup_codes = hashes
+    db.session.commit()
+    _log_activity("2fa_enable", "Enabled two-factor authentication")
+    return render_template("twofa_backup_codes.html", codes=plaintext, first_time=True)
+
+
+@app.route("/settings/2fa/disable", methods=["POST"])
+@login_required
+def twofa_disable():
+    """Turn 2FA off. Requires re-proving identity (current password or a valid
+    code) so a hijacked open session can't silently strip the second factor."""
+    if not current_user.totp_enabled:
+        return redirect(url_for("settings"))
+    pw = request.form.get("password", "")
+    code = request.form.get("code", "").strip()
+    secret = crypto_util.decrypt(current_user.totp_secret_encrypted)
+    ok = bool(pw) and current_user.check_password(pw)
+    if not ok and code:
+        ok = twofa.verify_code(secret, code)
+    if not ok:
+        flash("Enter your current password (or a valid code) to turn off two-factor.", "error")
+        return redirect(url_for("settings"))
+    current_user.totp_enabled = False
+    current_user.totp_secret_encrypted = ""
+    current_user.totp_backup_codes = ""
+    db.session.commit()
+    _log_activity("2fa_disable", "Disabled two-factor authentication")
+    flash("Two-factor authentication is off.", "success")
+    return redirect(url_for("settings"))
+
+
+@app.route("/settings/2fa/backup-codes", methods=["POST"])
+@login_required
+def twofa_regenerate_codes():
+    if not current_user.totp_enabled:
+        return redirect(url_for("settings"))
+    secret = crypto_util.decrypt(current_user.totp_secret_encrypted)
+    if not twofa.verify_code(secret, request.form.get("code", "")):
+        flash("Enter a current code from your authenticator to regenerate backup codes.", "error")
+        return redirect(url_for("settings"))
+    plaintext, hashes = twofa.generate_backup_codes()
+    current_user.totp_backup_codes = hashes
+    db.session.commit()
+    _log_activity("2fa_backup_regen", "Regenerated 2FA backup codes")
+    return render_template("twofa_backup_codes.html", codes=plaintext, first_time=False)
 
 
 @app.route("/settings/upload-rate-sheet", methods=["POST"])

--- a/app.py
+++ b/app.py
@@ -240,6 +240,28 @@ LOGO_MAX_PIXELS = 40_000_000  # 40 MP — far larger than any real logo
 Image.MAX_IMAGE_PIXELS = LOGO_MAX_PIXELS
 
 
+@app.template_filter("localtime")
+def localtime_filter(dt, style="dt"):
+    """Render a stored-UTC datetime as a <time> element that base.html's
+    localizer converts to the VIEWER'S timezone. Falls back to a UTC-labeled
+    string when JS is unavailable. Styles: 'dt' (Jan 5, 14:32),
+    'date' (Jan 5, 2026), 'full' (Jan 5, 2026, 14:32)."""
+    from markupsafe import Markup, escape
+    if not dt:
+        return ""
+    aware = dt if dt.tzinfo else dt.replace(tzinfo=timezone.utc)
+    iso = aware.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    if style == "date":
+        fallback = aware.strftime("%b %d, %Y")
+    elif style == "full":
+        fallback = aware.strftime("%b %d, %Y %H:%M UTC")
+    else:
+        fallback = aware.strftime("%b %d, %H:%M UTC")
+    return Markup(
+        f'<time datetime="{iso}" data-utc="{iso}" data-style="{escape(style)}">{escape(fallback)}</time>'
+    )
+
+
 @app.context_processor
 def inject_branding():
     return dict(
@@ -710,6 +732,7 @@ def inject_nav_context():
         setup_progress=_setup_progress(current_user),
         nav_active_projects=active_count,
         nav_org_name=(nav_org.name if nav_org else "") or "",
+        nav_trial_days=billing.trial_days_left(nav_org) if nav_org else 0,
     )
 
 
@@ -1295,21 +1318,40 @@ def _inline_redline_markdown(old_md: str, new_md: str) -> str:
 # Dashboard
 # ---------------------------------------------------------------------------
 
-def _project_focus_entry(p, now_naive):
+def _focus_context(active_projects) -> dict:
+    """Bulk-load everything _project_focus_entry needs for the dashboard focus
+    list in a fixed number of queries (previously 4+ queries per project)."""
+    ids = [p.id for p in active_projects]
+    latest = _latest_proposals_for(ids)
+    latest_ids = [prop.id for prop in latest.values()]
+    return {
+        "latest": latest,
+        "docs": _counts_by(
+            ProjectDocument.project_id, ProjectDocument.id,
+            ProjectDocument.project_id.in_(ids)) if ids else {},
+        "pending_q": _counts_by(
+            ProposalQuestion.project_id, ProposalQuestion.id,
+            ProposalQuestion.project_id.in_(ids),
+            ProposalQuestion.status == "pending") if ids else {},
+        "scopes": {s.project_id: s for s in ProjectScope.query.filter(
+            ProjectScope.project_id.in_(ids)).all()} if ids else {},
+        "pending_req": _counts_by(
+            RevisionRequest.proposal_id, RevisionRequest.id,
+            RevisionRequest.proposal_id.in_(latest_ids),
+            RevisionRequest.status == "pending") if latest_ids else {},
+    }
+
+
+def _project_focus_entry(p, now_naive, ctx):
     """Build a 'pick up where you left off' entry for an active project.
 
     Determines the single next action based on the latest proposal's
-    lifecycle state (or the pre-generation state of the project).
+    lifecycle state (or the pre-generation state of the project). All lookups
+    come from the prefetched `ctx` (see _focus_context) — no per-row queries.
     """
-    latest_prop = (
-        Proposal.query.filter_by(project_id=p.id)
-        .order_by(Proposal.generated_at.desc())
-        .first()
-    )
-    doc_count = ProjectDocument.query.filter_by(project_id=p.id).count()
-    pending_questions = ProposalQuestion.query.filter_by(
-        project_id=p.id, status="pending"
-    ).count()
+    latest_prop = ctx["latest"].get(p.id)
+    doc_count = ctx["docs"].get(p.id, 0)
+    pending_questions = ctx["pending_q"].get(p.id, 0)
 
     action_label = "Open"
     action_url = url_for("project_upload", project_id=p.id)
@@ -1322,7 +1364,7 @@ def _project_focus_entry(p, now_naive):
         chip = ("Your move", "chip-gold")
         sub = f"{pending_questions} clarification question(s) awaiting answers"
     elif latest_prop is None:
-        scope = ProjectScope.query.filter_by(project_id=p.id).first()
+        scope = ctx["scopes"].get(p.id)
         if doc_count == 0:
             action_label = "Upload documents"
             chip = ("Needs documents", "chip-neutral")
@@ -1342,9 +1384,7 @@ def _project_focus_entry(p, now_naive):
             sub = "Scope approved · awaiting AI draft"
     else:
         rs = latest_prop.review_status or "draft"
-        pending_req = RevisionRequest.query.filter_by(
-            proposal_id=latest_prop.id, status="pending"
-        ).count()
+        pending_req = ctx["pending_req"].get(latest_prop.id, 0)
         if rs == "draft":
             action_label = "Send for review"
             action_url = url_for("view_proposal", proposal_id=latest_prop.id)
@@ -1526,16 +1566,16 @@ def dashboard():
             ).scalar() or 0
             pipeline_by_status[status] = {"count": cnt, "value": val}
 
+    # Bulk context for the focus list + role widgets (fixed query count)
+    focus_ctx = _focus_context(active_projects)
+
     # Proposal-focused extras: docs needing proposals, recent generations
     pending_docs_projects = []
     recent_proposals = []
     if user_role == "proposal":
-        # Projects with docs but no proposals
-        my_projects = Project.query.filter(my_project_filter, Project.status == "active").all()
-        for p in my_projects:
-            doc_count = ProjectDocument.query.filter_by(project_id=p.id).count()
-            prop_count = Proposal.query.filter_by(project_id=p.id).count()
-            if doc_count > 0 and prop_count == 0:
+        for p in active_projects:
+            doc_count = focus_ctx["docs"].get(p.id, 0)
+            if doc_count > 0 and p.id not in focus_ctx["latest"]:
                 pending_docs_projects.append({"project": p, "doc_count": doc_count})
         recent_proposals = Proposal.query.join(Project).filter(
             my_project_filter
@@ -1667,7 +1707,7 @@ def dashboard():
         })
 
     for p in active_projects:
-        entry = _project_focus_entry(p, now_naive)
+        entry = _project_focus_entry(p, now_naive, focus_ctx)
         if entry:
             focus_items.append(entry)
 
@@ -1743,8 +1783,29 @@ PROPOSAL_FILTERS = [
 ]
 
 
+def _latest_proposals_for(project_ids) -> dict:
+    """{project_id: newest Proposal} in ONE query (newest-first, first wins)."""
+    latest = {}
+    if not project_ids:
+        return latest
+    for prop in (Proposal.query.filter(Proposal.project_id.in_(project_ids))
+                 .order_by(Proposal.generated_at.desc()).all()):
+        latest.setdefault(prop.project_id, prop)
+    return latest
+
+
+def _counts_by(column, count_of, *filters) -> dict:
+    """Generic bulk counter: {key_column_value: count}."""
+    q = db.session.query(column, db.func.count(count_of)).filter(*filters).group_by(column)
+    return dict(q.all())
+
+
 def _build_proposal_rows():
-    """Load all accessible projects enriched with their latest proposal state."""
+    """Load all accessible projects enriched with their latest proposal state.
+
+    Bulk-loads in a FIXED number of queries — previously this ran 3 extra
+    queries per project, so the proposals page degraded linearly with
+    pipeline size."""
     if current_user.is_admin:
         projects = Project.query.filter_by(org_id=current_user.org_id).order_by(
             Project.updated_at.desc()
@@ -1754,20 +1815,25 @@ def _build_proposal_rows():
             Project.updated_at.desc()
         ).all()
 
+    project_ids = [p.id for p in projects]
+    latest_by_project = _latest_proposals_for(project_ids)
+    doc_counts = _counts_by(
+        ProjectDocument.project_id, ProjectDocument.id,
+        ProjectDocument.project_id.in_(project_ids),
+    ) if project_ids else {}
+    latest_ids = [prop.id for prop in latest_by_project.values()]
+    pending_by_proposal = _counts_by(
+        RevisionRequest.proposal_id, RevisionRequest.id,
+        RevisionRequest.proposal_id.in_(latest_ids),
+        RevisionRequest.status == "pending",
+    ) if latest_ids else {}
+
     now_naive = datetime.utcnow()
     rows = []
     for p in projects:
-        latest = (
-            Proposal.query.filter_by(project_id=p.id)
-            .order_by(Proposal.generated_at.desc())
-            .first()
-        )
-        doc_count = ProjectDocument.query.filter_by(project_id=p.id).count()
-        pending_req = 0
-        if latest:
-            pending_req = RevisionRequest.query.filter_by(
-                proposal_id=latest.id, status="pending"
-            ).count()
+        latest = latest_by_project.get(p.id)
+        doc_count = doc_counts.get(p.id, 0)
+        pending_req = pending_by_proposal.get(latest.id, 0) if latest else 0
 
         overdue = False
         if p.due_date and p.status == "active":
@@ -1881,6 +1947,9 @@ def _apply_row_query_filters(rows):
     return rows
 
 
+PROPOSALS_PER_PAGE = 50
+
+
 @app.route("/proposals")
 @login_required
 def proposals_list():
@@ -1891,6 +1960,19 @@ def proposals_list():
     all_rows = _build_proposal_rows()
     counts = {key: len(_filter_proposal_rows(all_rows, key)) for key, _, _ in PROPOSAL_FILTERS}
     rows = _apply_row_query_filters(_filter_proposal_rows(all_rows, flt))
+
+    # Paginate the table view (the board stays whole — a paged kanban would
+    # misrepresent column totals; it's cheap now that loading is bulk).
+    view = request.args.get("view", "table")
+    try:
+        page = max(int(request.args.get("page", 1)), 1)
+    except (TypeError, ValueError):
+        page = 1
+    total_rows = len(rows)
+    total_pages = max((total_rows + PROPOSALS_PER_PAGE - 1) // PROPOSALS_PER_PAGE, 1)
+    page = min(page, total_pages)
+    if view != "board":
+        rows = rows[(page - 1) * PROPOSALS_PER_PAGE: page * PROPOSALS_PER_PAGE]
 
     proposal_users = _org_proposal_users()
 
@@ -1915,7 +1997,11 @@ def proposals_list():
         f_vertical=request.args.get("vertical", ""),
         sort=request.args.get("sort", "updated"),
         direction=request.args.get("dir", "desc"),
-        view=request.args.get("view", "table"),
+        view=view,
+        page=page,
+        total_pages=total_pages,
+        total_rows=total_rows,
+        per_page=PROPOSALS_PER_PAGE,
     )
 
 
@@ -4387,11 +4473,34 @@ def edit_proposal(proposal_id):
             flash("Proposal content cannot be empty.", "error")
             return redirect(url_for("edit_proposal", proposal_id=proposal_id))
 
-        # Get current version number
         latest = ProposalVersion.query.filter_by(proposal_id=proposal_id).order_by(
             ProposalVersion.version_number.desc()
         ).first()
-        next_version = (latest.version_number + 1) if latest else 1
+        current_num = latest.version_number if latest else 0
+
+        # Edit-conflict guard: if someone saved a newer version while this
+        # editor was open, refuse the silent last-write-wins clobber and
+        # re-render with the submitted text preserved (never discard work).
+        base_version = request.form.get("base_version", "").strip()
+        if base_version and base_version != str(current_num):
+            flash(
+                f"Save blocked: v{current_num} was saved by someone else while you "
+                "were editing. Your text is preserved below — review and save again.",
+                "error",
+            )
+            versions = ProposalVersion.query.filter_by(proposal_id=proposal_id).order_by(
+                ProposalVersion.version_number.desc()
+            ).all()
+            return render_template(
+                "proposal_edit.html",
+                proposal=proposal,
+                project=project,
+                current_content=new_content,
+                versions=versions,
+                base_version=current_num,
+            )
+
+        next_version = current_num + 1
 
         # Save new version
         version = ProposalVersion(
@@ -4444,6 +4553,7 @@ def edit_proposal(proposal_id):
         project=project,
         current_content=current_content,
         versions=versions,
+        base_version=(versions[0].version_number if versions else 0),
     )
 
 
@@ -5958,31 +6068,45 @@ def admin_panel():
 
     from sqlalchemy import func
 
-    # Per-user stats
+    # Per-user stats — bulk group-bys (previously 6 queries per member)
+    user_ids = [u.id for u in users]
+    proj_counts = _counts_by(Project.user_id, Project.id,
+                             Project.user_id.in_(user_ids)) if user_ids else {}
+    won_counts = _counts_by(Project.user_id, Project.id,
+                            Project.user_id.in_(user_ids),
+                            Project.status == "won") if user_ids else {}
+    lost_counts = _counts_by(Project.user_id, Project.id,
+                             Project.user_id.in_(user_ids),
+                             Project.status == "lost") if user_ids else {}
+    dollar_sums = dict(db.session.query(
+        Project.user_id, func.sum(Project.dollar_amount)
+    ).filter(Project.user_id.in_(user_ids), Project.dollar_amount > 0)
+     .group_by(Project.user_id).all()) if user_ids else {}
+    prop_counts = dict(db.session.query(
+        Project.user_id, func.count(Proposal.id)
+    ).join(Proposal, Proposal.project_id == Project.id)
+     .filter(Project.user_id.in_(user_ids))
+     .group_by(Project.user_id).all()) if user_ids else {}
+    last_activity = dict(db.session.query(
+        ActivityLog.user_id, func.max(ActivityLog.created_at)
+    ).filter(ActivityLog.user_id.in_(user_ids))
+     .group_by(ActivityLog.user_id).all()) if user_ids else {}
+
     user_stats = []
     for user in users:
-        total = Project.query.filter_by(user_id=user.id).count()
-        won = Project.query.filter_by(user_id=user.id, status="won").count()
-        lost = Project.query.filter_by(user_id=user.id, status="lost").count()
+        won = won_counts.get(user.id, 0)
+        lost = lost_counts.get(user.id, 0)
         decided = won + lost
-        total_dollar = db.session.query(func.sum(Project.dollar_amount)).filter(
-            Project.user_id == user.id, Project.dollar_amount > 0
-        ).scalar() or 0
-        proposal_count = Proposal.query.join(Project).filter(Project.user_id == user.id).count()
-
-        # Last activity timestamp
-        last_log = ActivityLog.query.filter_by(user_id=user.id).order_by(ActivityLog.created_at.desc()).first()
-        last_active = last_log.created_at.strftime('%Y-%m-%d') if last_log else None
-
+        last_ts = last_activity.get(user.id)
         user_stats.append({
             "user": user,
-            "total_projects": total,
-            "proposal_count": proposal_count,
+            "total_projects": proj_counts.get(user.id, 0),
+            "proposal_count": prop_counts.get(user.id, 0),
             "won": won,
             "lost": lost,
             "win_rate": round((won / decided) * 100) if decided > 0 else 0,
-            "total_dollar": total_dollar,
-            "last_active": last_active,
+            "total_dollar": dollar_sums.get(user.id, 0) or 0,
+            "last_active": last_ts.strftime('%Y-%m-%d') if last_ts else None,
         })
 
     # Organization-wide totals
@@ -6317,6 +6441,9 @@ def billing_page():
         usage=usage,
         stripe_enabled=billing.stripe_enabled(),
         is_admin=current_user.is_admin,
+        trial_active=billing.trial_active(org),
+        trial_days=billing.trial_days_left(org),
+        trial_ends=(org.trial_ends_at if org else None),
     )
 
 
@@ -6656,7 +6783,16 @@ def document_library():
     else:
         doc_query = doc_query.order_by(ProjectDocument.uploaded_at.desc())
 
-    documents = doc_query.all()
+    # SQL-side pagination — the library previously loaded every document row
+    try:
+        page = max(int(request.args.get("page", 1)), 1)
+    except (TypeError, ValueError):
+        page = 1
+    per_page = 50
+    filtered_count = doc_query.count()
+    total_pages = max((filtered_count + per_page - 1) // per_page, 1)
+    page = min(page, total_pages)
+    documents = doc_query.offset((page - 1) * per_page).limit(per_page).all()
 
     # Build project lookup
     project_map = {p.id: p for p in all_projects}
@@ -6673,15 +6809,20 @@ def document_library():
     ).scalar() or 0
     total_docs = ProjectDocument.query.filter(ProjectDocument.project_id.in_(project_ids)).count()
 
-    # Per-project stats
-    project_stats = []
-    for p in all_projects:
-        p_docs = ProjectDocument.query.filter_by(project_id=p.id).count()
-        p_size = db.session.query(func.sum(ProjectDocument.file_size)).filter(
-            ProjectDocument.project_id == p.id
-        ).scalar() or 0
-        if p_docs > 0:
-            project_stats.append({"project": p, "doc_count": p_docs, "total_size": p_size})
+    # Per-project stats in one group-by (was 2 queries per project)
+    per_project = {
+        pid: (cnt, size or 0)
+        for pid, cnt, size in db.session.query(
+            ProjectDocument.project_id,
+            func.count(ProjectDocument.id),
+            func.sum(ProjectDocument.file_size),
+        ).filter(ProjectDocument.project_id.in_(project_ids))
+         .group_by(ProjectDocument.project_id).all()
+    } if project_ids else {}
+    project_stats = [
+        {"project": p, "doc_count": per_project[p.id][0], "total_size": per_project[p.id][1]}
+        for p in all_projects if p.id in per_project
+    ]
 
     # Generated proposals
     proposals = Proposal.query.filter(
@@ -6712,6 +6853,9 @@ def document_library():
         filter_status=filter_status,
         sort_by=sort_by,
         show_reference=show_reference,
+        page=page,
+        total_pages=total_pages,
+        filtered_count=filtered_count,
     )
 
 
@@ -7347,27 +7491,40 @@ def search():
     )
     results["documents"] = doc_query.order_by(ProjectDocument.uploaded_at.desc()).limit(25).all()
 
-    # Proposals — search within markdown content of their latest version
-    prop_query = Proposal.query.filter(Proposal.project_id.in_(accessible_project_ids))
+    # Proposals — match within the LATEST version's markdown, SQL-side.
+    # (Previously loaded up to 200 proposals' full content into Python per
+    # search request.)
+    from sqlalchemy import func as _f
+    latest_v = db.session.query(
+        ProposalVersion.proposal_id,
+        _f.max(ProposalVersion.version_number).label("maxv"),
+    ).group_by(ProposalVersion.proposal_id).subquery()
+    version_hits = (
+        db.session.query(ProposalVersion, Proposal)
+        .join(latest_v, db.and_(
+            ProposalVersion.proposal_id == latest_v.c.proposal_id,
+            ProposalVersion.version_number == latest_v.c.maxv,
+        ))
+        .join(Proposal, Proposal.id == ProposalVersion.proposal_id)
+        .filter(Proposal.project_id.in_(accessible_project_ids),
+                ProposalVersion.markdown_content.ilike(like))
+        .limit(25)
+        .all()
+    )
     proposal_matches = []
-    for prop in prop_query.limit(200).all():
-        latest = ProposalVersion.query.filter_by(proposal_id=prop.id).order_by(
-            ProposalVersion.version_number.desc()
-        ).first()
-        if latest and q.lower() in (latest.markdown_content or "").lower():
-            # Extract a small snippet around the match
-            content = latest.markdown_content
-            lower = content.lower()
-            idx = lower.find(q.lower())
-            start = max(0, idx - 60)
-            end = min(len(content), idx + len(q) + 60)
-            snippet = content[start:end].replace("\n", " ")
-            if start > 0:
-                snippet = "…" + snippet
-            if end < len(content):
-                snippet = snippet + "…"
-            proposal_matches.append({"proposal": prop, "snippet": snippet})
-    results["proposals"] = proposal_matches[:25]
+    for version, prop in version_hits:
+        content = version.markdown_content or ""
+        idx = content.lower().find(q.lower())
+        idx = max(idx, 0)
+        start = max(0, idx - 60)
+        end = min(len(content), idx + len(q) + 60)
+        snippet = content[start:end].replace("\n", " ")
+        if start > 0:
+            snippet = "…" + snippet
+        if end < len(content):
+            snippet = snippet + "…"
+        proposal_matches.append({"proposal": prop, "snippet": snippet})
+    results["proposals"] = proposal_matches
 
     # Comments — always scoped to accessible (org) proposals
     if True:

--- a/app.py
+++ b/app.py
@@ -12,6 +12,7 @@ Full-featured intranet application with:
 """
 
 import difflib
+import hashlib
 import hmac
 import json
 import logging
@@ -251,7 +252,12 @@ def inject_branding():
 
 @login_manager.user_loader
 def load_user(user_id):
-    return db.session.get(User, user_id)
+    user = db.session.get(User, user_id)
+    # Deactivated (offboarded) members are logged out everywhere immediately —
+    # returning None invalidates any session they still hold.
+    if user is not None and user.is_active is False:
+        return None
+    return user
 
 
 @app.route("/healthz")
@@ -309,6 +315,15 @@ def _csrf_protect():
 
 
 @app.before_request
+def _ensure_job_workers():
+    """Start the background job pollers in every web process (idempotent,
+    no-op in inline/test mode). Previously workers only started in the process
+    that enqueued a job — if that process died on deploy, queued jobs sat
+    stranded until some other user happened to enqueue."""
+    jobs.start_workers()
+
+
+@app.before_request
 def _tag_ai_usage():
     """Attribute any LLM calls made while serving this request to the current
     org/user, so token usage is metered and the monthly AI budget is enforced.
@@ -356,6 +371,39 @@ def _login_rate_limited(key: str) -> bool:
 
 def _record_login_attempt(key: str):
     _LOGIN_ATTEMPTS.setdefault(key, []).append(time.time())
+
+
+# Signup throttle: each free workspace gets platform-funded AI budget, so
+# unlimited signups from one network is a scriptable spend attack.
+_SIGNUP_ATTEMPTS: dict[str, list[float]] = {}
+_SIGNUP_MAX_PER_WINDOW = 5
+_SIGNUP_WINDOW_SECONDS = 3600
+
+
+def _signup_rate_limited(ip: str) -> bool:
+    now = time.time()
+    attempts = [t for t in _SIGNUP_ATTEMPTS.get(ip, []) if now - t < _SIGNUP_WINDOW_SECONDS]
+    _SIGNUP_ATTEMPTS[ip] = attempts
+    return len(attempts) >= _SIGNUP_MAX_PER_WINDOW
+
+
+def _record_signup(ip: str):
+    _SIGNUP_ATTEMPTS.setdefault(ip, []).append(time.time())
+
+
+# In-process AI-endpoint throttle (chat / editor assist) per user.
+_AI_CALLS: dict[str, list[float]] = {}
+
+
+def _ai_rate_limited(key: str, max_calls: int, window: int = 60) -> bool:
+    now = time.time()
+    calls = [t for t in _AI_CALLS.get(key, []) if now - t < window]
+    if len(calls) >= max_calls:
+        _AI_CALLS[key] = calls
+        return True
+    calls.append(now)
+    _AI_CALLS[key] = calls
+    return False
 
 
 with app.app_context():
@@ -476,12 +524,27 @@ def _org_users_query():
 
 
 def _org_proposal_users():
-    """Org members who can be assigned proposals (proposal + admin roles)."""
+    """Active org members who can be assigned proposals (proposal + admin roles)."""
     return (
         _org_users_query()
-        .filter(User.role.in_(["proposal", "admin"]))
+        .filter(User.role.in_(["proposal", "admin"]), User.is_active.isnot(False))
         .order_by(User.display_name)
         .all()
+    )
+
+
+def _platform_ai_gate() -> tuple[bool, str]:
+    """Using the platform's built-in API key requires a verified email — curbs
+    throwaway-signup abuse of platform-funded AI. Users generating with their
+    OWN key (and invited members, who are auto-verified) are unaffected."""
+    if current_user.email_verified:
+        return True, ""
+    if decrypt_api_key(current_user.api_key_encrypted):
+        return True, ""
+    return False, (
+        "Please verify your email address before using the built-in AI "
+        "(check your inbox, or use 'Resend verification email' in the banner "
+        "above). Alternatively, add your own Anthropic API key in Settings."
     )
 
 
@@ -542,14 +605,17 @@ def _setup_progress(user) -> dict:
     Returns dict with 'steps' (list of {key,title,desc,done,url_endpoint,anchor}),
     'done' count, 'total' count, and 'complete' bool.
     """
+    org = db.session.get(Organization, user.org_id) if user.org_id else None
+    org_named = bool(org and (org.name or "").strip()
+                     and not org.name.endswith("'s Workspace"))
     steps = [
         {
             "key": "company",
-            "title": "Add your company profile",
+            "title": "Name your company workspace",
             "desc": "Company name used to brand generated proposals.",
             "endpoint": "settings",
             "anchor": "",
-            "done": bool((user.company_name or "").strip()),
+            "done": org_named,
         },
         {
             "key": "logo",
@@ -557,7 +623,7 @@ def _setup_progress(user) -> dict:
             "desc": "Placed on proposal cover pages and headers.",
             "endpoint": "posture",
             "anchor": "#branding",
-            "done": bool(user.company_logo_path),
+            "done": bool(org and org.logo_path),
         },
         {
             "key": "template",
@@ -631,7 +697,7 @@ def _setup_progress(user) -> dict:
 def inject_nav_context():
     """Sidebar counts + setup wizard progress for the app shell."""
     if not (hasattr(current_user, "id") and current_user.is_authenticated):
-        return dict(setup_progress=None, nav_active_projects=0)
+        return dict(setup_progress=None, nav_active_projects=0, nav_org_name="")
     active_count = Project.query.filter(
         db.or_(
             Project.user_id == current_user.id,
@@ -639,9 +705,11 @@ def inject_nav_context():
         ),
         Project.status == "active",
     ).count()
+    nav_org = db.session.get(Organization, current_user.org_id) if current_user.org_id else None
     return dict(
         setup_progress=_setup_progress(current_user),
         nav_active_projects=active_count,
+        nav_org_name=(nav_org.name if nav_org else "") or "",
     )
 
 
@@ -676,6 +744,17 @@ def _save_upload(file, subdir: str = "") -> tuple[str, str, int]:
     return safe, str(dest), size
 
 
+def _extract_text_chars(path: str):
+    """Parse receipt for an uploaded document: how many characters of
+    machine-readable text it yields. 0 = parsed but empty (e.g. a scanned
+    image PDF the AI can't read); None = format we couldn't check. Lets the
+    UI warn at UPLOAD time instead of failing minutes later at generation."""
+    try:
+        return len(parse_document(path).strip())
+    except Exception:
+        return None
+
+
 def _send_stored_file(path, **kwargs):
     """send_file wrapper that fetches the file from object storage first if the
     local copy is missing (ephemeral disk / multi-instance safety)."""
@@ -701,26 +780,38 @@ def _proposal_markdown(proposal) -> str:
     return ""
 
 
-def _logo_docx_kwargs(user, company_name_override: str = "") -> dict:
-    """Build the logo-related kwargs passed into markdown_to_docx so they
-    respect the user's branding preferences."""
-    if not getattr(user, "company_logo_path", None):
-        return {"font_name": user.font_preference or "Calibri"}
-    if not getattr(user, "company_logo_use_in_proposals", False):
-        return {"font_name": user.font_preference or "Calibri"}
-    logo_path = user.company_logo_path
-    if not Path(logo_path).exists():
-        return {"font_name": user.font_preference or "Calibri"}
+def _org_for_project(project):
+    """The organization that owns a project (branding source of truth)."""
+    org_id = _owner_org_id(project) if project else None
+    return db.session.get(Organization, org_id) if org_id else None
+
+
+def _logo_docx_kwargs(org, font_user=None) -> dict:
+    """Logo/branding kwargs for markdown_to_docx. Branding is ORG-level so
+    every member's generations carry the same workspace identity; only the
+    body font follows the acting user's preference."""
+    font = (getattr(font_user, "font_preference", "") or "Calibri")
+    if org is None or not (org.logo_path or "") or not org.logo_use_in_proposals:
+        return {"font_name": font}
+    storage.ensure_local(org.logo_path)
+    if not Path(org.logo_path).exists():
+        return {"font_name": font}
     return {
-        "logo_path": logo_path,
-        "logo_placement": user.company_logo_placement or "top_left",
-        "logo_on_cover": bool(getattr(user, "company_logo_show_on_cover", False)),
-        "company_name": company_name_override or (user.company_name or ""),
-        "font_name": user.font_preference or "Calibri",
+        "logo_path": org.logo_path,
+        "logo_placement": org.logo_placement or "top_left",
+        "logo_on_cover": bool(org.logo_show_on_cover),
+        "company_name": org.name or "",
+        "font_name": font,
     }
 
 
-def _process_and_save_logo(file, user_id: str) -> tuple[str, str, int]:
+def _project_brand_kwargs(project, font_user) -> dict:
+    """DOCX branding kwargs for a project: the owning ORG's logo/identity with
+    the acting user's font preference."""
+    return _logo_docx_kwargs(_org_for_project(project), font_user=font_user)
+
+
+def _process_and_save_logo(file, owner_id: str) -> tuple[str, str, int]:
     """Load an uploaded image, auto-orient, resize to a reasonable size,
     and save as an optimized PNG. Transparency is preserved where possible.
 
@@ -728,7 +819,7 @@ def _process_and_save_logo(file, user_id: str) -> tuple[str, str, int]:
     Raises ValueError on an unreadable/invalid image.
     """
     original_name = secure_filename(file.filename or "logo")
-    dest_dir = UPLOADS_DIR / f"logos/{user_id}"
+    dest_dir = UPLOADS_DIR / f"logos/{owner_id}"
     dest_dir.mkdir(parents=True, exist_ok=True)
     unique = f"logo_{uuid.uuid4().hex[:8]}.png"
     dest = dest_dir / unique
@@ -803,6 +894,10 @@ def signup():
     if request.method == "GET":
         return render_template("signup.html", invitation=None, invite_org=None)
 
+    if not app.testing and _signup_rate_limited(request.remote_addr or "?"):
+        flash("Too many new accounts from this network. Please try again later.", "error")
+        return redirect(url_for("signup"))
+
     username = request.form.get("username", "").strip()
     email = request.form.get("email", "").strip()
     password = request.form.get("password", "")
@@ -826,6 +921,15 @@ def signup():
     if User.query.filter_by(username=username).first():
         flash("Username already taken.", "error")
         return redirect(url_for("signup"))
+
+    # Email must be globally unique (case-insensitive) — duplicates break
+    # password reset and verification. For invited signups validate the
+    # INVITED address, since that's what the account is bound to.
+    effective_email = invitation.email if invitation else email
+    if User.query.filter(User.email.ilike(effective_email)).first():
+        flash("An account with that email address already exists. "
+              "Sign in instead, or use the password reset if you've forgotten it.", "error")
+        return redirect(url_for("login"))
 
     user = User(
         username=username,
@@ -866,6 +970,7 @@ def signup():
         db.session.add(user)
 
     db.session.commit()
+    _record_signup(request.remote_addr or "?")
     session.permanent = True
     login_user(user)
     _log_activity("signup", f"User {username} created account")
@@ -922,6 +1027,12 @@ def login():
         flash("Invalid username or password.", "error")
         return redirect(url_for("login"))
 
+    # Deactivated members can't sign in (checked after password verification so
+    # probing can't distinguish "wrong password" from "deactivated").
+    if user.is_active is False:
+        flash("This account has been deactivated. Contact your workspace admin.", "error")
+        return redirect(url_for("login"))
+
     _LOGIN_ATTEMPTS.pop(rl_key, None)
     if user.failed_login_count or user.lockout_until:
         user.failed_login_count = 0
@@ -937,20 +1048,33 @@ def login():
 # Email verification & password reset
 # ---------------------------------------------------------------------------
 
-def _issue_token(user, purpose: str, hours: int = 24) -> UserToken:
+def _hash_token(raw: str) -> str:
+    """Reset/verify tokens are stored hashed so a DB leak can't be replayed
+    into an account takeover. SHA-256 hex fits the existing 64-char column."""
+    return hashlib.sha256((raw or "").encode("utf-8")).hexdigest()
+
+
+def _issue_token(user, purpose: str, hours: int = 24) -> str:
+    """Create a single-use token and return the RAW value (for the emailed
+    link). Only its hash is persisted."""
     from datetime import timedelta
+    raw = uuid.uuid4().hex + uuid.uuid4().hex
     tok = UserToken(
         user_id=user.id,
         purpose=purpose,
+        token=_hash_token(raw),
         expires_at=datetime.utcnow() + timedelta(hours=hours),
     )
     db.session.add(tok)
     db.session.commit()
-    return tok
+    return raw
 
 
 def _consume_token(token_str: str, purpose: str):
-    tok = UserToken.query.filter_by(token=token_str, purpose=purpose).first()
+    tok = UserToken.query.filter_by(token=_hash_token(token_str), purpose=purpose).first()
+    if tok is None:
+        # Legacy rows created before hashing stored the raw token.
+        tok = UserToken.query.filter_by(token=token_str, purpose=purpose).first()
     if not tok or tok.used_at:
         return None
     if tok.expires_at:
@@ -961,8 +1085,8 @@ def _consume_token(token_str: str, purpose: str):
 
 
 def _send_verification_email(user):
-    tok = _issue_token(user, "verify", hours=72)
-    link = url_for("verify_email", token=tok.token, _external=True)
+    raw = _issue_token(user, "verify", hours=72)
+    link = url_for("verify_email", token=raw, _external=True)
     import mailer
     sent = mailer.send_email(
         to=user.email,
@@ -1010,8 +1134,8 @@ def forgot_password():
     generic = "If an account exists for that email, a reset link has been sent."
     user = User.query.filter(User.email.ilike(email)).first() if email else None
     if user:
-        tok = _issue_token(user, "reset", hours=2)
-        link = url_for("reset_password", token=tok.token, _external=True)
+        raw = _issue_token(user, "reset", hours=2)
+        link = url_for("reset_password", token=raw, _external=True)
         import mailer
         sent = mailer.send_email(
             to=user.email,
@@ -1313,8 +1437,12 @@ def quick_start():
     db.session.add(project)
     db.session.flush()
 
+    unreadable = []
     for f in valid:
         safe, path, size = _save_upload(f, f"projects/{project.id}")
+        chars = _extract_text_chars(path)
+        if chars == 0:
+            unreadable.append(safe)
         db.session.add(ProjectDocument(
             project_id=project.id,
             filename=f"{uuid.uuid4().hex[:8]}_{safe}",
@@ -1322,9 +1450,14 @@ def quick_start():
             file_type="rfp",
             file_path=path,
             file_size=size,
+            text_chars=chars,
         ))
 
     db.session.commit()
+    if unreadable:
+        flash("Heads up: no readable text could be extracted from "
+              f"{', '.join(unreadable)} — it may be a scanned image. "
+              "The AI won't be able to analyze it.", "error")
     _log_activity("project_quick_start", f"Quick-started project from {len(valid)} file(s)", project.id)
     _notify_role(
         "proposal", "rfp_uploaded",
@@ -1862,6 +1995,7 @@ def posture():
 
     return render_template(
         "posture.html",
+        org=db.session.get(Organization, current_user.org_id) if current_user.org_id else None,
         rate_sheets=rate_sheets,
         user_templates=user_templates,
         staff_roles=staff_roles,
@@ -1892,23 +2026,54 @@ def setup_wizard():
 @login_required
 def settings():
     if request.method == "POST":
+        org = db.session.get(Organization, current_user.org_id) if current_user.org_id else None
+
         current_user.display_name = request.form.get("display_name", current_user.display_name)
-        current_user.email = request.form.get("email", current_user.email)
-        current_user.company_name = request.form.get("company_name", current_user.company_name)
+
+        # Changing the email requires re-verification (otherwise "verified"
+        # would silently apply to an address that was never confirmed), and
+        # the new address must not collide with another account.
+        new_email = request.form.get("email", current_user.email).strip()
+        if new_email and new_email.lower() != (current_user.email or "").lower():
+            clash = User.query.filter(
+                User.email.ilike(new_email), User.id != current_user.id
+            ).first()
+            if clash:
+                flash("That email address is already in use by another account.", "error")
+                return redirect(url_for("settings"))
+            current_user.email = new_email
+            current_user.email_verified = False
+            try:
+                _send_verification_email(current_user)
+                flash("Email updated — please verify your new address "
+                      "(we sent a verification link).", "success")
+            except Exception:
+                pass
+
+        # Company identity is workspace-level; only admins may rename it.
+        company_name = request.form.get("company_name", "").strip()
+        if org and company_name and current_user.is_admin and company_name != org.name:
+            org.name = company_name[:300]
+
         current_user.font_preference = request.form.get("font_preference", current_user.font_preference)
-        current_user.llm_provider = request.form.get("llm_provider", current_user.llm_provider)
+        # Anthropic is the only supported provider — ignore anything else.
+        current_user.llm_provider = "anthropic"
         current_user.llm_model = request.form.get("llm_model", current_user.llm_model)
 
         api_key = request.form.get("api_key", "").strip()
         if api_key:
             current_user.api_key_encrypted = encrypt_api_key(api_key)
 
-        # Company logo preferences (checkboxes come through only when checked)
-        current_user.company_logo_use_in_proposals = bool(request.form.get("company_logo_use_in_proposals"))
-        current_user.company_logo_show_on_cover = bool(request.form.get("company_logo_show_on_cover"))
-        placement = request.form.get("company_logo_placement", current_user.company_logo_placement or "top_left")
-        if placement in ("top_left", "center"):
-            current_user.company_logo_placement = placement
+        # Workspace branding preferences. Only touched when the form actually
+        # carries them (signaled by the placement field both branding-aware
+        # forms always include) — otherwise any unrelated POST to /settings
+        # would silently zero the checkbox flags.
+        if org and "company_logo_placement" in request.form:
+            org.logo_use_in_proposals = bool(request.form.get("company_logo_use_in_proposals"))
+            org.logo_show_on_cover = bool(request.form.get("company_logo_show_on_cover"))
+            placement = request.form.get("company_logo_placement") or (org.logo_placement or "top_left")
+            if placement in ("top_left", "center"):
+                org.logo_placement = placement
 
         db.session.commit()
         _log_activity("settings_update", "Updated user settings")
@@ -1936,6 +2101,7 @@ def settings():
 
     return render_template(
         "settings.html",
+        org=db.session.get(Organization, current_user.org_id) if current_user.org_id else None,
         rate_sheets=rate_sheets,
         user_templates=user_templates,
         staff_roles=staff_roles,
@@ -1947,6 +2113,29 @@ def settings():
         verticals=VERTICALS,
         logo_max_dimension=LOGO_MAX_DIMENSION,
     )
+
+
+@app.route("/settings/change-password", methods=["POST"])
+@login_required
+def change_password():
+    """In-app password change (previously only the forgot-password flow existed)."""
+    current = request.form.get("current_password", "")
+    new = request.form.get("new_password", "")
+    confirm = request.form.get("confirm_password", "")
+    if not current_user.check_password(current):
+        flash("Your current password is incorrect.", "error")
+        return redirect(url_for("settings"))
+    if len(new) < 8:
+        flash("New password must be at least 8 characters.", "error")
+        return redirect(url_for("settings"))
+    if new != confirm:
+        flash("New passwords do not match.", "error")
+        return redirect(url_for("settings"))
+    current_user.set_password(new)
+    db.session.commit()
+    _log_activity("password_change", "Changed account password")
+    flash("Password updated.", "success")
+    return redirect(url_for("settings"))
 
 
 @app.route("/settings/upload-rate-sheet", methods=["POST"])
@@ -2204,6 +2393,10 @@ def delete_rate_sheet(sheet_id):
     sheet = db.session.get(UserRateSheet, sheet_id)
     if not sheet or sheet.org_id != current_user.org_id:
         abort(404)
+    try:
+        storage.delete(sheet.file_path)
+    except Exception:
+        pass
     db.session.delete(sheet)
     db.session.commit()
     flash("Rate sheet deleted.", "success")
@@ -2216,6 +2409,10 @@ def delete_user_template(template_id):
     tmpl = db.session.get(UserVerticalTemplate, template_id)
     if not tmpl or tmpl.org_id != current_user.org_id:
         abort(404)
+    try:
+        storage.delete(tmpl.file_path)
+    except Exception:
+        pass
     db.session.delete(tmpl)
     db.session.commit()
     flash("Template deleted.", "success")
@@ -2241,26 +2438,28 @@ def upload_company_logo():
         )
         return redirect(url_for("posture") + "#branding")
 
+    org = db.session.get(Organization, current_user.org_id)
+    if org is None:
+        abort(400)
+
     try:
-        original_name, saved_path, saved_size = _process_and_save_logo(file, current_user.id)
+        original_name, saved_path, saved_size = _process_and_save_logo(file, org.id)
     except ValueError as e:
         flash(f"Could not process image: {e}", "error")
         return redirect(url_for("posture") + "#branding")
+    storage.sync_up(saved_path)
 
-    # Remove old logo file if any
-    if current_user.company_logo_path:
+    # Remove old logo file if any (local + object storage)
+    if org.logo_path:
         try:
-            old = Path(current_user.company_logo_path)
-            if old.exists() and old.is_file():
-                old.unlink()
+            storage.delete(org.logo_path)
         except Exception:
             pass
 
-    current_user.company_logo_path = saved_path
-    current_user.company_logo_original_name = original_name
-    # If this is the user's first logo upload, default "use in proposals" to True
-    if not current_user.company_logo_placement:
-        current_user.company_logo_placement = "top_left"
+    org.logo_path = saved_path
+    org.logo_original_name = original_name
+    if not org.logo_placement:
+        org.logo_placement = "top_left"
     db.session.commit()
     _log_activity("logo_upload", f"Uploaded company logo ({saved_size // 1024} KB)")
     flash(
@@ -2274,16 +2473,15 @@ def upload_company_logo():
 @app.route("/settings/delete-logo", methods=["POST"])
 @login_required
 def delete_company_logo():
-    if current_user.company_logo_path:
+    org = db.session.get(Organization, current_user.org_id)
+    if org and org.logo_path:
         try:
-            old = Path(current_user.company_logo_path)
-            if old.exists() and old.is_file():
-                old.unlink()
+            storage.delete(org.logo_path)
         except Exception:
             pass
-    current_user.company_logo_path = ""
-    current_user.company_logo_original_name = ""
-    db.session.commit()
+        org.logo_path = ""
+        org.logo_original_name = ""
+        db.session.commit()
     _log_activity("logo_delete", "Removed company logo")
     flash("Company logo removed.", "success")
     return redirect(url_for("posture") + "#branding")
@@ -2292,10 +2490,12 @@ def delete_company_logo():
 @app.route("/settings/logo-preview")
 @login_required
 def company_logo_preview():
-    """Serve the current user's company logo (private — only to the owner)."""
-    if not current_user.company_logo_path:
+    """Serve the workspace logo (members only)."""
+    org = db.session.get(Organization, current_user.org_id)
+    if not org or not org.logo_path:
         abort(404)
-    logo_path = Path(current_user.company_logo_path)
+    storage.ensure_local(org.logo_path)
+    logo_path = Path(org.logo_path)
     if not logo_path.exists():
         abort(404)
     return send_file(str(logo_path), mimetype="image/png")
@@ -2494,9 +2694,9 @@ def add_travel_rate():
         safe, path, size = _save_upload(uploaded_file, "rate_sheets")
         sheet = UserRateSheet(
             user_id=current_user.id,
-        org_id=current_user.org_id,
+            org_id=current_user.org_id,
             name=f"Travel Rates - {safe}",
-            sheet_type="labor_rates",
+            sheet_type="travel_rates",
             file_path=path,
             original_filename=safe,
         )
@@ -2663,9 +2863,13 @@ def project_upload(project_id):
         files = request.files.getlist("documents")
         file_type = request.form.get("file_type", "rfp")
 
+        unreadable = []
         for file in files:
             if file and _allowed_file(file.filename, ALLOWED_EXTENSIONS | {"xlsx", "xls"}):
                 safe, path, size = _save_upload(file, f"projects/{project_id}")
+                chars = _extract_text_chars(path)
+                if chars == 0 and file_type in ("rfp", "supporting", "legal"):
+                    unreadable.append(safe)
                 doc = ProjectDocument(
                     project_id=project_id,
                     filename=f"{uuid.uuid4().hex[:8]}_{safe}",
@@ -2673,10 +2877,15 @@ def project_upload(project_id):
                     file_type=file_type,
                     file_path=path,
                     file_size=size,
+                    text_chars=chars,
                 )
                 db.session.add(doc)
 
         db.session.commit()
+        if unreadable:
+            flash("Heads up: no readable text could be extracted from "
+                  f"{', '.join(unreadable)} — it may be a scanned image. "
+                  "The AI won't be able to analyze it.", "error")
         _log_activity("document_upload", f"Uploaded {len(files)} document(s)", project_id)
         # Notify proposal users when RFPs are uploaded
         _notify_role(
@@ -2753,6 +2962,12 @@ def project_generate(project_id):
     project = db.session.get(Project, project_id)
     if not _can_access_project(project):
         abort(404)
+
+    # Abuse gate: platform-key AI requires a verified email
+    ok, msg = _platform_ai_gate()
+    if not ok:
+        flash(msg, "error")
+        return redirect(url_for("project_upload", project_id=project_id))
 
     # Plan gate (Phase 5): enforce monthly generation limits
     allowed, limit_msg = billing_check_generation(current_user.org_id)
@@ -2843,7 +3058,10 @@ def _perform_generation(project_id, user, vertical, output_format, cost_options,
 
     set_progress("reading", "Reading uploaded documents…")
     documents = ProjectDocument.query.filter_by(project_id=project_id).all()
-    rfp_docs = [d for d in documents if d.file_type in ("rfp", "supporting")]
+    # Legal/contract docs carry terms the proposal must honor — include them.
+    # (Drawings stay out: image-heavy PDFs parse to noise; rate sheets are
+    # folded into the pricing context below instead.)
+    rfp_docs = [d for d in documents if d.file_type in ("rfp", "supporting", "legal")]
     combined_text = ""
     for doc in rfp_docs:
         try:
@@ -2919,17 +3137,33 @@ def _perform_generation(project_id, user, vertical, output_format, cost_options,
                 for t in rates
             ]
 
-    # Load user rate sheets (Excel uploads)
-    rate_sheet_data = None
-    active_sheets = UserRateSheet.query.filter_by(org_id=org_id, is_active=True).all()
-    if active_sheets:
-        rate_sheet_data = {}
-        for sheet in active_sheets:
-            try:
-                storage.ensure_local(sheet.file_path)
-                rate_sheet_data[sheet.sheet_type] = parse_rate_sheet(sheet.file_path)
-            except Exception:
-                continue
+    # Load org rate sheets (posture uploads). Multiple sheets of the same type
+    # are MERGED — previously each one silently overwrote the last.
+    rate_sheet_data = {}
+    for sheet in UserRateSheet.query.filter_by(org_id=org_id, is_active=True).all():
+        try:
+            storage.ensure_local(sheet.file_path)
+            parsed = parse_rate_sheet(sheet.file_path)
+        except Exception:
+            continue
+        entry = rate_sheet_data.setdefault(sheet.sheet_type, {"raw_text": ""})
+        raw = parsed.get("raw_text", "")
+        if raw:
+            entry["raw_text"] += (("\n\n" if entry["raw_text"] else "") + raw)
+
+    # Project documents uploaded as type 'rate_sheet' were previously ignored
+    # entirely — fold their content into the pricing context too.
+    for doc in documents:
+        if doc.file_type != "rate_sheet":
+            continue
+        try:
+            storage.ensure_local(doc.file_path)
+            raw = parse_document(doc.file_path)
+        except Exception:
+            continue
+        if raw.strip():
+            rate_sheet_data[f"project sheet {doc.original_filename[:60]}"] = {"raw_text": raw}
+    rate_sheet_data = rate_sheet_data or None
 
     user_templates = _load_org_templates(org_id, vertical)
 
@@ -2980,13 +3214,15 @@ def _perform_generation(project_id, user, vertical, output_format, cost_options,
         for r in answered_rows if (r.answer or "").strip()
     ]
 
+    _gen_org = db.session.get(Organization, org_id) if org_id else None
+
     set_progress("drafting", "Claude is drafting your proposal…")
     result = generate_proposal(
         combined_text,
         vertical=vertical,
         rate_sheet_data=rate_sheet_data,
         user_templates=user_templates,
-        company_name=user.company_name,
+        company_name=(_gen_org.name if _gen_org else "") or "",
         user_api_key=decrypt_api_key(user.api_key_encrypted) or None,
         user_model=user.llm_model or None,
         answered_questions=answered_questions or None,
@@ -3058,7 +3294,7 @@ def _perform_generation(project_id, user, vertical, output_format, cost_options,
     markdown_to_docx(
         result["proposal_markdown"],
         str(docx_path),
-        **_logo_docx_kwargs(_brand_user),
+        **_project_brand_kwargs(project, _brand_user),
     )
     storage.sync_up(docx_path)
 
@@ -3226,36 +3462,66 @@ def project_scope(project_id):
 @app.route("/projects/<project_id>/scope/generate", methods=["POST"])
 @login_required
 def generate_scope(project_id):
-    """AI-draft (or re-draft) the Scope of Work from the uploaded documents."""
+    """AI-draft (or re-draft) the Scope of Work — runs as a background job so
+    the minutes-long AI call doesn't hold a web worker or time out at the LB."""
     project = db.session.get(Project, project_id)
     if not _can_access_project(project):
         abort(404)
 
-    combined_text = _project_rfp_text(project_id)
-    if not combined_text:
+    ok, msg = _platform_ai_gate()
+    if not ok:
+        flash(msg, "error")
+        return redirect(url_for("project_upload", project_id=project_id))
+
+    has_docs = ProjectDocument.query.filter_by(project_id=project_id).filter(
+        ProjectDocument.file_type.in_(("rfp", "supporting", "legal"))
+    ).count() > 0
+    if not has_docs:
         flash("Upload an RFP/RFQ document before drafting the scope of work.", "error")
         return redirect(url_for("project_upload", project_id=project_id))
 
-    vertical = request.form.get("vertical", "auto")
+    job = jobs.enqueue(
+        "draft_scope",
+        {"project_id": project_id, "vertical": request.form.get("vertical", "auto")},
+        user_id=current_user.id,
+        org_id=current_user.org_id,
+    )
+    return redirect(url_for("job_status_page", job_id=job.id))
 
-    try:
-        result = draft_scope_of_work(
-            combined_text,
-            vertical=vertical,
-            company_name=current_user.company_name,
-            user_api_key=decrypt_api_key(current_user.api_key_encrypted) or None,
-            user_model=current_user.llm_model or None,
-        )
-    except RuntimeError as e:
-        flash(str(e), "error")
-        return redirect(url_for("project_upload", project_id=project_id))
-    except Exception as e:
-        flash(f"Scope drafting failed: {friendly_api_error(e)}", "error")
-        return redirect(url_for("project_upload", project_id=project_id))
 
-    # Replace any existing scope (regeneration starts fresh)
+def _perform_scope_draft(project_id, user, vertical, set_progress):
+    """Draft/re-draft the scope inside a background job. Items the TEAM added
+    by hand survive a re-draft — only AI-proposed items are replaced."""
+    project = db.session.get(Project, project_id)
+    if not project:
+        raise RuntimeError("Project no longer exists.")
+
+    set_progress("reading", "Reading uploaded documents…")
+    combined_text = _project_rfp_text(project_id)
+    if not combined_text:
+        raise RuntimeError("Could not extract text from the uploaded documents.")
+
+    org = db.session.get(Organization, user.org_id) if user.org_id else None
+
+    set_progress("drafting", "Claude is drafting the scope of work…")
+    result = draft_scope_of_work(
+        combined_text,
+        vertical=vertical,
+        company_name=(org.name if org else "") or "",
+        user_api_key=decrypt_api_key(user.api_key_encrypted) or None,
+        user_model=user.llm_model or None,
+    )
+
+    set_progress("saving", "Saving scope items…")
+    # Preserve team-added items across re-drafts; replace only AI items.
+    human_items = []
     existing = ProjectScope.query.filter_by(project_id=project_id).first()
     if existing:
+        human_items = [
+            {"text": i.item_text, "category": i.category, "status": i.status}
+            for i in ScopeItem.query.filter_by(scope_id=existing.id, source="human")
+            .order_by(ScopeItem.sort_order, ScopeItem.created_at).all()
+        ]
         ScopeItem.query.filter_by(scope_id=existing.id).delete()
         db.session.delete(existing)
         db.session.flush()
@@ -3270,7 +3536,8 @@ def generate_scope(project_id):
     db.session.add(scope)
     db.session.flush()
 
-    for idx, entry in enumerate(result["items"]):
+    idx = 0
+    for entry in result["items"]:
         db.session.add(ScopeItem(
             scope_id=scope.id,
             project_id=project_id,
@@ -3280,13 +3547,35 @@ def generate_scope(project_id):
             status="included",
             sort_order=idx,
         ))
+        idx += 1
+    for h in human_items:
+        db.session.add(ScopeItem(
+            scope_id=scope.id,
+            project_id=project_id,
+            item_text=h["text"],
+            category=h["category"],
+            source="human",
+            status=h["status"],
+            sort_order=idx,
+        ))
+        idx += 1
 
     project.vertical = result["vertical"]
     project.vertical_label = result["vertical_label"]
     db.session.commit()
-    _log_activity("scope_generate", f"AI drafted {len(result['items'])} scope item(s)", project_id)
-    flash(f"AI proposed {len(result['items'])} scope item(s). Review and approve below.", "success")
-    return redirect(url_for("project_scope", project_id=project_id))
+    _log_activity_for(user, "scope_generate",
+                      f"AI drafted {len(result['items'])} scope item(s)"
+                      + (f", kept {len(human_items)} team item(s)" if human_items else ""),
+                      project_id)
+    return {"redirect": url_for("project_scope", project_id=project_id)}
+
+
+@jobs.register("draft_scope")
+def _job_draft_scope(payload, job):
+    user = db.session.get(User, job.user_id)
+    def _sp(phase, message=""):
+        jobs.set_progress(job, phase, message)
+    return _perform_scope_draft(payload["project_id"], user, payload["vertical"], _sp)
 
 
 @app.route("/projects/<project_id>/scope/items/<item_id>/toggle", methods=["POST"])
@@ -3349,6 +3638,32 @@ def add_scope_item(project_id):
     db.session.commit()
     _log_activity("scope_item_add", f"Added scope item: {text[:80]}", project_id)
     flash("Scope item added.", "success")
+    return redirect(url_for("project_scope", project_id=project_id))
+
+
+@app.route("/projects/<project_id>/scope/items/<item_id>/edit", methods=["POST"])
+@login_required
+def edit_scope_item(project_id, item_id):
+    """Edit a scope item's text inline — core to actually negotiating the
+    scope with the AI (previously items could only be kept or struck)."""
+    project = db.session.get(Project, project_id)
+    if not _can_access_project(project):
+        abort(404)
+    item = db.session.get(ScopeItem, item_id)
+    if not item or item.project_id != project_id:
+        abort(404)
+    text = request.form.get("item_text", "").strip()
+    if not text:
+        flash("Scope item text is required.", "error")
+        return redirect(url_for("project_scope", project_id=project_id))
+    item.item_text = text
+    scope = db.session.get(ProjectScope, item.scope_id)
+    if scope and scope.status == "approved":
+        scope.status = "draft"
+        flash("Scope modified — re-approve it before generating.", "success")
+    db.session.commit()
+    _log_activity("scope_item_edit", f"Edited scope item: {text[:80]}", project_id)
+    flash("Scope item updated.", "success")
     return redirect(url_for("project_scope", project_id=project_id))
 
 
@@ -3737,17 +4052,18 @@ def _ensure_proposal_pdf(proposal, project):
         md_path = GENERATED_DIR / proposal.md_file
         md_text = md_path.read_text(encoding="utf-8") if md_path.exists() else ""
 
-    owner = project.owner or db.session.get(User, project.user_id)
+    org = _org_for_project(project)
     pdf_filename = proposal.pdf_file or f"proposal_{proposal.job_id}.pdf"
     pdf_path = GENERATED_DIR / pdf_filename
 
     logo_path = None
     company_name = ""
-    if owner:
-        company_name = owner.company_name or ""
-        if (owner.company_logo_path and getattr(owner, "company_logo_use_in_proposals", False)
-                and Path(owner.company_logo_path).exists()):
-            logo_path = owner.company_logo_path
+    if org:
+        company_name = org.name or ""
+        if org.logo_path and org.logo_use_in_proposals:
+            storage.ensure_local(org.logo_path)
+            if Path(org.logo_path).exists():
+                logo_path = org.logo_path
 
     markdown_to_pdf(md_text, str(pdf_path), logo_path=logo_path, company_name=company_name)
     storage.sync_up(pdf_path)
@@ -3802,7 +4118,7 @@ def proposal_estimate(proposal_id):
 @app.route("/proposal/<proposal_id>/estimate/draft", methods=["POST"])
 @login_required
 def draft_proposal_estimate(proposal_id):
-    """AI-draft a structured estimate from the RFP + the org's rates."""
+    """AI-draft a structured estimate — runs as a background job."""
     proposal = db.session.get(Proposal, proposal_id)
     if not proposal:
         abort(404)
@@ -3810,7 +4126,27 @@ def draft_proposal_estimate(proposal_id):
     if not _can_access_project(project):
         abort(404)
 
-    org_id = current_user.org_id
+    ok, msg = _platform_ai_gate()
+    if not ok:
+        flash(msg, "error")
+        return redirect(url_for("proposal_estimate", proposal_id=proposal_id))
+
+    job = jobs.enqueue(
+        "draft_estimate",
+        {"proposal_id": proposal_id},
+        user_id=current_user.id,
+        org_id=current_user.org_id,
+    )
+    return redirect(url_for("job_status_page", job_id=job.id))
+
+
+def _perform_estimate_draft(proposal_id, user, set_progress):
+    proposal = db.session.get(Proposal, proposal_id)
+    if not proposal:
+        raise RuntimeError("Proposal no longer exists.")
+    project = db.session.get(Project, proposal.project_id)
+
+    org_id = user.org_id
     staff = [{"role_name": r.role_name, "category": r.category, "hourly_rate": r.hourly_rate,
               "overtime_rate": r.overtime_rate}
              for r in StaffRole.query.filter_by(org_id=org_id, is_active=True).all()]
@@ -3825,21 +4161,18 @@ def draft_proposal_estimate(proposal_id):
         scope_items = [i.item_text for i in ScopeItem.query.filter_by(
             scope_id=scope.id, status="included").all()]
 
+    set_progress("reading", "Reading project documents and rates…")
     rfp_text = _project_rfp_text(project.id)
-    try:
-        result = draft_estimate(
-            rfp_text, staff_roles=staff, equipment=equip, travel=travel,
-            approved_scope=scope_items,
-            user_api_key=decrypt_api_key(current_user.api_key_encrypted) or None,
-            user_model=current_user.llm_model or None,
-        )
-    except RuntimeError as e:
-        flash(str(e), "error")
-        return redirect(url_for("proposal_estimate", proposal_id=proposal_id))
-    except Exception as e:
-        flash(f"Estimate drafting failed: {friendly_api_error(e)}", "error")
-        return redirect(url_for("proposal_estimate", proposal_id=proposal_id))
 
+    set_progress("drafting", "Claude is drafting the estimate…")
+    result = draft_estimate(
+        rfp_text, staff_roles=staff, equipment=equip, travel=travel,
+        approved_scope=scope_items,
+        user_api_key=decrypt_api_key(user.api_key_encrypted) or None,
+        user_model=user.llm_model or None,
+    )
+
+    set_progress("saving", "Saving line items…")
     existing = ProposalEstimate.query.filter_by(proposal_id=proposal_id).first()
     if existing:
         db.session.delete(existing)
@@ -3856,9 +4189,17 @@ def draft_proposal_estimate(proposal_id):
             quantity=it["quantity"], unit=it["unit"], unit_cost=it["unit_cost"], sort_order=idx,
         ))
     db.session.commit()
-    _log_activity("estimate_draft", f"AI drafted {len(result['items'])} estimate line(s)", project.id)
-    flash(f"AI drafted {len(result['items'])} line item(s). Review and adjust below.", "success")
-    return redirect(url_for("proposal_estimate", proposal_id=proposal_id))
+    _log_activity_for(user, "estimate_draft",
+                      f"AI drafted {len(result['items'])} estimate line(s)", project.id)
+    return {"redirect": url_for("proposal_estimate", proposal_id=proposal_id)}
+
+
+@jobs.register("draft_estimate")
+def _job_draft_estimate(payload, job):
+    user = db.session.get(User, job.user_id)
+    def _sp(phase, message=""):
+        jobs.set_progress(job, phase, message)
+    return _perform_estimate_draft(payload["proposal_id"], user, _sp)
 
 
 @app.route("/proposal/<proposal_id>/estimate/save", methods=["POST"])
@@ -4015,7 +4356,7 @@ def insert_estimate_into_proposal(proposal_id):
     if proposal.docx_file:
         docx_path = GENERATED_DIR / proposal.docx_file
         _brand_user = project.owner or current_user
-        markdown_to_docx(updated_md, str(docx_path), **_logo_docx_kwargs(_brand_user))
+        markdown_to_docx(updated_md, str(docx_path), **_project_brand_kwargs(project, _brand_user))
         storage.sync_up(docx_path)
     project.dollar_amount = _estimate_totals(estimate)["grand_total"]
     db.session.commit()
@@ -4076,7 +4417,7 @@ def edit_proposal(proposal_id):
             markdown_to_docx(
                 new_content,
                 str(docx_path),
-                **_logo_docx_kwargs(_brand_user),
+                **_project_brand_kwargs(project, _brand_user),
             )
             storage.sync_up(docx_path)
 
@@ -4140,6 +4481,9 @@ def ai_assist(proposal_id):
     if not text:
         return {"error": "Select some text first."}, 400
 
+    if _ai_rate_limited(f"assist:{current_user.id}", max_calls=10):
+        return {"error": "Too many AI edits at once — wait a minute and try again."}, 429
+
     instructions = {
         "tighten": "Rewrite this passage to be more concise and punchy without losing meaning.",
         "formal": "Rewrite this passage in a more formal, professional business tone.",
@@ -4154,8 +4498,9 @@ def ai_assist(proposal_id):
     if not key:
         return {"error": "No API key configured. Add one in Settings."}, 400
     try:
-        import anthropic
-        client = anthropic.Anthropic(api_key=key, timeout=45, max_retries=1)
+        # Metered client: records token usage and enforces the org's monthly AI
+        # budget (raw clients here previously bypassed both).
+        client = proposal_agent._make_client(key)
         import platform_config
         resp = client.messages.create(
             model=current_user.llm_model or platform_config.get("llm_model", "claude-opus-4-8"),
@@ -4237,7 +4582,7 @@ def restore_version(proposal_id, version_id):
         markdown_to_docx(
             version.markdown_content,
             str(docx_path),
-            **_logo_docx_kwargs(_brand_user),
+            **_project_brand_kwargs(project, _brand_user),
         )
         storage.sync_up(docx_path)
 
@@ -4793,32 +5138,65 @@ def apply_feedback(proposal_id):
             lifecycle_labels=LIFECYCLE_LABELS,
         )
 
-    # POST — collect selected request ids & edited directives
+    # POST — validate the selection, then hand the minutes-long AI revision to a
+    # background job (previously ran inline, holding a web worker and risking a
+    # load-balancer timeout on the largest AI call in the app).
     selected_ids = request.form.getlist("apply_request_id")
     if not selected_ids:
         flash("Please select at least one revision request to apply.", "error")
         return redirect(url_for("apply_feedback", proposal_id=proposal_id))
 
-    selected_requests = []
+    valid_ids = []
+    directives = {}
     for rid in selected_ids:
         req = db.session.get(RevisionRequest, rid)
         if not req or req.proposal_id != proposal_id or req.status != "pending":
             continue
+        valid_ids.append(rid)
         # Allow owner to edit the directive inline before the AI sees it
         edited = request.form.get(f"directive_{rid}", "").strip()
         if edited:
-            req.directive = edited
-        selected_requests.append(req)
+            directives[rid] = edited
 
-    if not selected_requests:
+    if not valid_ids:
         flash("No valid requests selected.", "error")
         return redirect(url_for("apply_feedback", proposal_id=proposal_id))
 
-    # Build the AI payload
-    current_version = latest_version(proposal_id)
-    if not current_version:
+    if not latest_version(proposal_id):
         flash("Proposal has no version to revise.", "error")
         return redirect(url_for("view_proposal", proposal_id=proposal_id))
+
+    job = jobs.enqueue(
+        "revise_proposal",
+        {"proposal_id": proposal_id, "request_ids": valid_ids, "directives": directives},
+        user_id=current_user.id,
+        org_id=current_user.org_id,
+    )
+    return redirect(url_for("job_status_page", job_id=job.id))
+
+
+def _perform_revision(proposal_id, user, request_ids, directives, set_progress):
+    """Apply a batch of revision requests with AI. Runs inside a background job."""
+    proposal = db.session.get(Proposal, proposal_id)
+    if not proposal:
+        raise RuntimeError("Proposal no longer exists.")
+    project = db.session.get(Project, proposal.project_id)
+
+    set_progress("reading", "Collecting revision requests and context…")
+    selected_requests = []
+    for rid in request_ids:
+        req = db.session.get(RevisionRequest, rid)
+        if not req or req.proposal_id != proposal_id or req.status != "pending":
+            continue
+        if directives.get(rid):
+            req.directive = directives[rid]
+        selected_requests.append(req)
+    if not selected_requests:
+        raise RuntimeError("The selected revision requests are no longer pending.")
+
+    current_version = latest_version(proposal_id)
+    if not current_version:
+        raise RuntimeError("Proposal has no version to revise.")
 
     ai_payload = []
     for r in selected_requests:
@@ -4833,9 +5211,7 @@ def apply_feedback(proposal_id):
             "author_label": f"{author_label} — {role_label}",
         })
 
-    # Load supporting context
-    owner = _proposal_owner(proposal)
-    owner_id = owner.id if owner else current_user.id
+    org = _org_for_project(project)
     standards = CompanyStandard.query.filter_by(org_id=_owner_org_id(project), is_active=True).all()
     standards_data = [
         {"category": s.category, "title": s.title, "content": s.content}
@@ -4856,32 +5232,26 @@ def apply_feedback(proposal_id):
         for c in corrections
     ] if corrections else None
 
-    try:
-        result = revise_proposal(
-            current_markdown=current_version.markdown_content,
-            revision_requests=ai_payload,
-            vertical=proposal.vertical,
-            company_name=current_user.company_name,
-            user_api_key=decrypt_api_key(current_user.api_key_encrypted) or None,
-            user_model=current_user.llm_model or None,
-            company_standards=standards_data,
-            past_corrections=corrections_data,
-        )
-    except RuntimeError as e:
-        flash(str(e), "error")
-        return redirect(url_for("apply_feedback", proposal_id=proposal_id))
-    except Exception as e:
-        flash(f"AI revision failed: {friendly_api_error(e)}", "error")
-        return redirect(url_for("apply_feedback", proposal_id=proposal_id))
+    set_progress("drafting", "Claude is applying the revision requests…")
+    result = revise_proposal(
+        current_markdown=current_version.markdown_content,
+        revision_requests=ai_payload,
+        vertical=proposal.vertical,
+        company_name=(org.name if org else "") or "",
+        user_api_key=decrypt_api_key(user.api_key_encrypted) or None,
+        user_model=user.llm_model or None,
+        company_standards=standards_data,
+        past_corrections=corrections_data,
+    )
 
-    # Create the new version
+    set_progress("saving", "Formatting and saving the new version…")
     latest_num = current_version.version_number
     new_version = ProposalVersion(
         proposal_id=proposal_id,
         version_number=latest_num + 1,
         markdown_content=result["revised_markdown"],
         edit_source="ai",
-        editor_id=current_user.id,
+        editor_id=user.id,
         change_summary=f"AI revision: {result['ai_summary']}",
     )
     db.session.add(new_version)
@@ -4893,9 +5263,8 @@ def apply_feedback(proposal_id):
     storage.sync_up(md_path)
     if proposal.docx_file:
         docx_path = GENERATED_DIR / proposal.docx_file
-        _brand_user = project.owner or current_user
         markdown_to_docx(result["revised_markdown"], str(docx_path),
-                         **_logo_docx_kwargs(_brand_user))
+                         **_project_brand_kwargs(project, project.owner or user))
         storage.sync_up(docx_path)
 
     # Update action items count
@@ -4908,7 +5277,7 @@ def apply_feedback(proposal_id):
         proposal_id=proposal_id,
         from_version_id=current_version.id,
         to_version_id=new_version.id,
-        triggered_by=current_user.id,
+        triggered_by=user.id,
         request_count=len(selected_requests),
         ai_change_summary=json.dumps({
             "summary": result["ai_summary"],
@@ -4929,7 +5298,7 @@ def apply_feedback(proposal_id):
             "revision_requested", "in_review", "internally_approved", "customer_feedback"
         ):
             lifecycle_transition(
-                proposal, "in_review", current_user.id,
+                proposal, "in_review", user.id,
                 note=f"AI generated v{new_version.version_number} from {len(selected_requests)} request(s)."
             )
     except LifecycleError:
@@ -4938,7 +5307,7 @@ def apply_feedback(proposal_id):
     # Notify reviewers a new version needs their attention
     reviewers = ProposalReviewer.query.filter_by(proposal_id=proposal_id).all()
     for rv in reviewers:
-        if rv.user_id == current_user.id:
+        if rv.user_id == user.id:
             continue
         _notify(
             rv.user_id,
@@ -4949,16 +5318,22 @@ def apply_feedback(proposal_id):
         )
 
     db.session.commit()
-    _log_activity(
+    _log_activity_for(
+        user,
         "proposal_revise",
         f"AI-revised proposal to v{new_version.version_number} ({len(selected_requests)} requests applied)",
         project.id,
     )
-    flash(
-        f"Version {new_version.version_number} generated. {len(selected_requests)} request(s) applied.",
-        "success",
-    )
-    return redirect(url_for("view_proposal", proposal_id=proposal_id))
+    return {"redirect": url_for("view_proposal", proposal_id=proposal_id)}
+
+
+@jobs.register("revise_proposal")
+def _job_revise_proposal(payload, job):
+    user = db.session.get(User, job.user_id)
+    def _sp(phase, message=""):
+        jobs.set_progress(job, phase, message)
+    return _perform_revision(payload["proposal_id"], user, payload["request_ids"],
+                             payload.get("directives") or {}, _sp)
 
 
 @app.route("/proposal/<proposal_id>/submit-to-customer", methods=["POST"])
@@ -5031,6 +5406,9 @@ def create_share(proposal_id):
     share.allow_comments = allow_comments
     share.allow_decision = allow_decision
     share.version_number = version.version_number if version else 0
+    # Share links carry accept/decline authority — they must not live forever.
+    # Every (re)share extends the window rather than leaving it open-ended.
+    share.expires_at = datetime.now(timezone.utc) + timedelta(days=90)
     db.session.flush()
 
     # Advance lifecycle if we're at the internally-approved gate
@@ -5050,8 +5428,9 @@ def create_share(proposal_id):
         except Exception:
             pdf_path = None
         import mailer
+        _share_org = _org_for_project(project)
         body = (
-            f"Hello,\n\n{current_user.company_name or 'We'} have prepared a proposal for "
+            f"Hello,\n\n{(_share_org.name if _share_org else '') or 'We'} have prepared a proposal for "
             f"{project.name}. You can review it online here:\n\n{share_url}\n\n"
         )
         if share.allow_decision:
@@ -5108,7 +5487,7 @@ def customer_portal(token):
 
     proposal = db.session.get(Proposal, share.proposal_id)
     project = db.session.get(Project, share.project_id)
-    owner = db.session.get(User, project.user_id) if project else None
+    brand_org = _org_for_project(project)
 
     # Record the view (dedupe rapid reloads within 60s from same IP)
     ip = request.headers.get("X-Forwarded-For", request.remote_addr or "").split(",")[0].strip()
@@ -5151,11 +5530,12 @@ def customer_portal(token):
     md_text = re.sub(r"\[ASSUMED:.*?\]", "", md_text, flags=re.DOTALL | re.IGNORECASE)
     proposal_html = htmlsafe.sanitize(md.markdown(md_text, extensions=["tables", "fenced_code"]))
 
-    company_name = (owner.company_name if owner else "") or ""
-    logo_url = url_for("portal_logo", token=token) if (
-        owner and owner.company_logo_path and getattr(owner, "company_logo_use_in_proposals", False)
-        and Path(owner.company_logo_path).exists()
-    ) else ""
+    company_name = (brand_org.name if brand_org else "") or ""
+    logo_url = ""
+    if brand_org and brand_org.logo_path and brand_org.logo_use_in_proposals:
+        storage.ensure_local(brand_org.logo_path)
+        if Path(brand_org.logo_path).exists():
+            logo_url = url_for("portal_logo", token=token)
 
     return render_template(
         "portal.html",
@@ -5173,11 +5553,13 @@ def portal_logo(token):
     share = _valid_share(token)
     if not share:
         abort(404)
-    project = db.session.get(Project, share.project_id)
-    owner = db.session.get(User, project.user_id) if project else None
-    if not owner or not owner.company_logo_path or not Path(owner.company_logo_path).exists():
+    org = _org_for_project(db.session.get(Project, share.project_id))
+    if not org or not org.logo_path:
         abort(404)
-    return send_file(owner.company_logo_path, mimetype="image/png")
+    storage.ensure_local(org.logo_path)
+    if not Path(org.logo_path).exists():
+        abort(404)
+    return send_file(org.logo_path, mimetype="image/png")
 
 
 @app.route("/p/<token>/comment", methods=["POST"])
@@ -6138,6 +6520,48 @@ def toggle_admin(user_id):
     return redirect(url_for("admin_panel"))
 
 
+@app.route("/admin/deactivate-user/<user_id>", methods=["POST"])
+@login_required
+def deactivate_user(user_id):
+    """Offboard a member: they can no longer sign in, existing sessions die on
+    next request, and their seat is freed. Their projects/data stay visible to
+    the org. Reversible via reactivate."""
+    if not current_user.is_admin:
+        abort(403)
+    if user_id == current_user.id:
+        flash("You cannot deactivate your own account.", "error")
+        return redirect(url_for("admin_panel"))
+    user = db.session.get(User, user_id)
+    if not user or not _same_org(user):
+        abort(404)
+    user.is_active = False
+    db.session.commit()
+    _log_activity("user_deactivate", f"Deactivated {user.username}")
+    flash(f"{user.display_name or user.username} deactivated. "
+          "They can no longer sign in; their seat is freed.", "success")
+    return redirect(url_for("admin_panel"))
+
+
+@app.route("/admin/reactivate-user/<user_id>", methods=["POST"])
+@login_required
+def reactivate_user(user_id):
+    if not current_user.is_admin:
+        abort(403)
+    user = db.session.get(User, user_id)
+    if not user or not _same_org(user):
+        abort(404)
+    # Reactivation consumes a seat again — enforce the plan limit.
+    ok, msg = billing_check_seat(current_user.org_id)
+    if not ok:
+        flash(msg, "error")
+        return redirect(url_for("billing_page"))
+    user.is_active = True
+    db.session.commit()
+    _log_activity("user_reactivate", f"Reactivated {user.username}")
+    flash(f"{user.display_name or user.username} reactivated.", "success")
+    return redirect(url_for("admin_panel"))
+
+
 @app.route("/admin/update-role/<user_id>", methods=["POST"])
 @login_required
 def update_user_role(user_id):
@@ -6315,6 +6739,104 @@ def preview_document(doc_id):
     if not _can_access_project(project):
         abort(404)
     return _send_stored_file(doc.file_path, as_attachment=False)
+
+
+@app.route("/documents/<doc_id>/delete", methods=["POST"])
+@login_required
+def delete_document(doc_id):
+    """Delete an uploaded document (row, tags, local file, and object-storage
+    copy). Previously there was no way to remove a mis-uploaded file at all."""
+    doc = db.session.get(ProjectDocument, doc_id)
+    if not doc:
+        abort(404)
+    project = db.session.get(Project, doc.project_id)
+    if not _can_access_project(project):
+        abort(404)
+    name = doc.original_filename
+    DocumentTag.query.filter_by(document_id=doc.id).delete()
+    try:
+        storage.delete(doc.file_path)
+    except Exception:
+        pass
+    db.session.delete(doc)
+    db.session.commit()
+    _log_activity("document_delete", f"Deleted document: {name}", project.id)
+    flash(f"'{name}' deleted.", "success")
+    return redirect(request.referrer or url_for("project_upload", project_id=project.id))
+
+
+@app.route("/projects/<project_id>/delete", methods=["POST"])
+@login_required
+def delete_project(project_id):
+    """Permanently delete a project and everything under it (documents,
+    proposals, versions, scope, estimates, shares…), including files on disk
+    and in object storage. Owner or org admin only."""
+    project = db.session.get(Project, project_id)
+    if not project:
+        abort(404)
+    is_owner = project.user_id == current_user.id
+    is_org_admin = current_user.is_admin and _same_org(project.org_id or _owner_org_id(project))
+    if not (is_owner or is_org_admin):
+        abort(404)
+    if request.form.get("confirm_name", "").strip() != project.name:
+        flash("Type the project's exact name to confirm deletion.", "error")
+        return redirect(url_for("project_upload", project_id=project_id))
+
+    name = project.name
+    proposal_ids = [p.id for p in Proposal.query.filter_by(project_id=project_id).all()]
+
+    # Generated proposal files (md/docx/pdf)
+    for prop in Proposal.query.filter_by(project_id=project_id).all():
+        for fname in (prop.md_file, prop.docx_file, prop.pdf_file):
+            if fname:
+                try:
+                    storage.delete(GENERATED_DIR / fname)
+                except Exception:
+                    pass
+
+    # Uploaded document files + tags
+    docs = ProjectDocument.query.filter_by(project_id=project_id).all()
+    for doc in docs:
+        try:
+            storage.delete(doc.file_path)
+        except Exception:
+            pass
+        DocumentTag.query.filter_by(document_id=doc.id).delete()
+
+    if proposal_ids:
+        # Children of proposals, leaves first (FKs are not ON DELETE CASCADE)
+        share_ids = [s.id for s in ProposalShare.query.filter(
+            ProposalShare.proposal_id.in_(proposal_ids)).all()]
+        if share_ids:
+            ShareView.query.filter(ShareView.share_id.in_(share_ids)).delete(synchronize_session=False)
+        ProposalShare.query.filter(ProposalShare.proposal_id.in_(proposal_ids)).delete(synchronize_session=False)
+        ProposalApproval.query.filter(ProposalApproval.proposal_id.in_(proposal_ids)).delete(synchronize_session=False)
+        ProposalReviewer.query.filter(ProposalReviewer.proposal_id.in_(proposal_ids)).delete(synchronize_session=False)
+        ProposalRevisionBatch.query.filter(ProposalRevisionBatch.proposal_id.in_(proposal_ids)).delete(synchronize_session=False)
+        RevisionRequest.query.filter(RevisionRequest.proposal_id.in_(proposal_ids)).delete(synchronize_session=False)
+        ProposalStatusHistory.query.filter(ProposalStatusHistory.proposal_id.in_(proposal_ids)).delete(synchronize_session=False)
+        ProposalComment.query.filter(ProposalComment.proposal_id.in_(proposal_ids)).delete(synchronize_session=False)
+        ReviewComment.query.filter(ReviewComment.proposal_id.in_(proposal_ids)).delete(synchronize_session=False)
+        ReviewCycle.query.filter(ReviewCycle.proposal_id.in_(proposal_ids)).delete(synchronize_session=False)
+        ProposalCorrection.query.filter(ProposalCorrection.proposal_id.in_(proposal_ids)).delete(synchronize_session=False)
+        est_ids = [e.id for e in ProposalEstimate.query.filter(
+            ProposalEstimate.proposal_id.in_(proposal_ids)).all()]
+        if est_ids:
+            EstimateLineItem.query.filter(EstimateLineItem.estimate_id.in_(est_ids)).delete(synchronize_session=False)
+        ProposalEstimate.query.filter(ProposalEstimate.proposal_id.in_(proposal_ids)).delete(synchronize_session=False)
+        ProposalVersion.query.filter(ProposalVersion.proposal_id.in_(proposal_ids)).delete(synchronize_session=False)
+
+    ClarificationItem.query.filter_by(project_id=project_id).delete(synchronize_session=False)
+    ProposalQuestion.query.filter_by(project_id=project_id).delete(synchronize_session=False)
+    ScopeItem.query.filter_by(project_id=project_id).delete(synchronize_session=False)
+    ProjectScope.query.filter_by(project_id=project_id).delete(synchronize_session=False)
+    ProjectDocument.query.filter_by(project_id=project_id).delete(synchronize_session=False)
+    Proposal.query.filter_by(project_id=project_id).delete(synchronize_session=False)
+    db.session.delete(project)
+    db.session.commit()
+    _log_activity("project_delete", f"Deleted project: {name}")
+    flash(f"Project '{name}' and all its data were permanently deleted.", "success")
+    return redirect(url_for("proposals_list"))
 
 
 @app.route("/documents/<doc_id>/tags", methods=["POST"])
@@ -7413,7 +7935,8 @@ def generate_rfi_letter(project_id):
     db.session.commit()
 
     # Generate DOCX
-    company_name = current_user.company_name or "Our Company"
+    _rfi_org = _org_for_project(project)
+    company_name = (_rfi_org.name if _rfi_org else "") or "Our Company"
     rfi_filename = f"rfi_letter_{project_id[:8]}_{datetime.now(timezone.utc).strftime('%Y%m%d')}.docx"
     rfi_path = GENERATED_DIR / rfi_filename
 
@@ -7580,12 +8103,13 @@ def regenerate_proposal_section(proposal_id):
             continue
 
     try:
+        _sec_org = _org_for_project(project)
         result = regenerate_section(
             full_proposal_md=current_md,
             section_heading=section_heading,
             clarification_answer=clarification_answer,
             original_rfp_text=rfp_text,
-            company_name=current_user.company_name,
+            company_name=(_sec_org.name if _sec_org else ""),
             user_api_key=decrypt_api_key(current_user.api_key_encrypted) or None,
             user_model=current_user.llm_model or None,
         )
@@ -7624,7 +8148,7 @@ def regenerate_proposal_section(proposal_id):
             docx_path = GENERATED_DIR / proposal.docx_file
             _brand_user = project.owner or current_user
             markdown_to_docx(updated_md, str(docx_path),
-                             **_logo_docx_kwargs(_brand_user))
+                             **_project_brand_kwargs(project, _brand_user))
             storage.sync_up(docx_path)
 
         # Update action items count
@@ -7805,6 +8329,9 @@ def chat_help():
     if not message:
         return {"reply": "Please type a question and I'll do my best to help!"}
 
+    if _ai_rate_limited(f"chat:{current_user.id}", max_calls=20):
+        return {"reply": "You're sending messages very quickly — give me a minute to catch up."}
+
     def _record(reply, answered_by):
         # Store the Q&A for platform-owner analytics (best-effort).
         try:
@@ -7821,8 +8348,9 @@ def chat_help():
     effective_key = api_key or platform_config.get("anthropic_api_key")
     if effective_key:
         try:
-            import anthropic
-            client = anthropic.Anthropic(api_key=effective_key, timeout=30, max_retries=1)
+            # Metered client: chat usage counts toward the org's AI budget and
+            # is recorded like every other LLM call.
+            client = proposal_agent._make_client(effective_key)
             resp = client.messages.create(
                 model=current_user.llm_model or platform_config.get("llm_model", "claude-opus-4-8"),
                 max_tokens=400,

--- a/app.py
+++ b/app.py
@@ -68,6 +68,7 @@ import billing
 import crypto_util
 import htmlsafe
 import jobs
+import ocr
 import proposal_agent
 import storage
 from document_parser import parse_document
@@ -800,13 +801,35 @@ def _save_upload(file, subdir: str = "") -> tuple[str, str, int]:
 
 def _extract_text_chars(path: str):
     """Parse receipt for an uploaded document: how many characters of
-    machine-readable text it yields. 0 = parsed but empty (e.g. a scanned
-    image PDF the AI can't read); None = format we couldn't check. Lets the
-    UI warn at UPLOAD time instead of failing minutes later at generation."""
+    machine-readable text it yields (fast pass — no OCR, so the upload request
+    stays quick). 0 = parsed but empty (e.g. a scanned image PDF); None =
+    format we couldn't check. Lets the UI warn at UPLOAD time instead of
+    failing minutes later at generation."""
     try:
         return len(parse_document(path).strip())
     except Exception:
         return None
+
+
+def _flag_unreadable(entries):
+    """Given [(filename, text_chars)], flash the right message: files that will
+    be recovered by OCR at generation vs. genuinely unreadable ones."""
+    scanned, unreadable = [], []
+    for name, chars in entries:
+        if chars != 0:
+            continue
+        if name.lower().endswith(".pdf") and ocr.available():
+            scanned.append(name)
+        else:
+            unreadable.append(name)
+    if scanned:
+        flash("Looks like a scan: " + ", ".join(scanned)
+              + " has no embedded text, but we'll read it with OCR when you "
+              "generate (it may take a little longer).", "success")
+    if unreadable:
+        flash("Heads up: no readable text could be extracted from "
+              + ", ".join(unreadable) + " — it may be a scanned image. "
+              "The AI won't be able to analyze it.", "error")
 
 
 def _send_stored_file(path, **kwargs):
@@ -1522,12 +1545,11 @@ def quick_start():
     db.session.add(project)
     db.session.flush()
 
-    unreadable = []
+    receipts = []
     for f in valid:
         safe, path, size = _save_upload(f, f"projects/{project.id}")
         chars = _extract_text_chars(path)
-        if chars == 0:
-            unreadable.append(safe)
+        receipts.append((safe, chars))
         db.session.add(ProjectDocument(
             project_id=project.id,
             filename=f"{uuid.uuid4().hex[:8]}_{safe}",
@@ -1539,10 +1561,7 @@ def quick_start():
         ))
 
     db.session.commit()
-    if unreadable:
-        flash("Heads up: no readable text could be extracted from "
-              f"{', '.join(unreadable)} — it may be a scanned image. "
-              "The AI won't be able to analyze it.", "error")
+    _flag_unreadable(receipts)
     _log_activity("project_quick_start", f"Quick-started project from {len(valid)} file(s)", project.id)
     _notify_role(
         "proposal", "rfp_uploaded",
@@ -3071,13 +3090,13 @@ def project_upload(project_id):
         files = request.files.getlist("documents")
         file_type = request.form.get("file_type", "rfp")
 
-        unreadable = []
+        receipts = []
         for file in files:
             if file and _allowed_file(file.filename, ALLOWED_EXTENSIONS | {"xlsx", "xls"}):
                 safe, path, size = _save_upload(file, f"projects/{project_id}")
                 chars = _extract_text_chars(path)
-                if chars == 0 and file_type in ("rfp", "supporting", "legal"):
-                    unreadable.append(safe)
+                if file_type in ("rfp", "supporting", "legal"):
+                    receipts.append((safe, chars))
                 doc = ProjectDocument(
                     project_id=project_id,
                     filename=f"{uuid.uuid4().hex[:8]}_{safe}",
@@ -3090,10 +3109,7 @@ def project_upload(project_id):
                 db.session.add(doc)
 
         db.session.commit()
-        if unreadable:
-            flash("Heads up: no readable text could be extracted from "
-                  f"{', '.join(unreadable)} — it may be a scanned image. "
-                  "The AI won't be able to analyze it.", "error")
+        _flag_unreadable(receipts)
         _log_activity("document_upload", f"Uploaded {len(files)} document(s)", project_id)
         # Notify proposal users when RFPs are uploaded
         _notify_role(
@@ -3149,6 +3165,7 @@ def project_upload(project_id):
         "project_upload.html",
         gen_limit=gen_limit,
         gens_used=gens_used,
+        ocr_enabled=ocr.available(),
         project=project,
         documents=documents,
         verticals=VERTICALS,
@@ -3281,7 +3298,7 @@ def _perform_generation(project_id, user, vertical, output_format, cost_options,
     for doc in rfp_docs:
         try:
             storage.ensure_local(doc.file_path)
-            text = parse_document(doc.file_path)
+            text = parse_document(doc.file_path, ocr=True)
             combined_text += f"\n\n--- Document: {doc.original_filename} ---\n\n{text}"
         except Exception:
             continue
@@ -3676,7 +3693,7 @@ def _project_rfp_text(project_id: str) -> str:
     for doc in rfp_docs:
         try:
             storage.ensure_local(doc.file_path)
-            text = parse_document(doc.file_path)
+            text = parse_document(doc.file_path, ocr=True)
             combined += f"\n\n--- Document: {doc.original_filename} ---\n\n{text}"
         except Exception:
             continue
@@ -7186,6 +7203,7 @@ def delete_document(doc_id):
     DocumentTag.query.filter_by(document_id=doc.id).delete()
     try:
         storage.delete(doc.file_path)
+        storage.delete(str(doc.file_path) + ".ocr.txt")  # OCR sidecar cache
     except Exception:
         pass
     db.session.delete(doc)
@@ -7229,6 +7247,7 @@ def delete_project(project_id):
     for doc in docs:
         try:
             storage.delete(doc.file_path)
+            storage.delete(str(doc.file_path) + ".ocr.txt")  # OCR sidecar cache
         except Exception:
             pass
         DocumentTag.query.filter_by(document_id=doc.id).delete()

--- a/app.py
+++ b/app.py
@@ -70,6 +70,7 @@ import htmlsafe
 import jobs
 import ocr
 import proposal_agent
+import sso
 import storage
 import twofa
 from document_parser import parse_document
@@ -1085,14 +1086,16 @@ def login():
     if current_user.is_authenticated:
         return redirect(url_for("dashboard"))
     if request.method == "GET":
-        return render_template("login.html", ident="")
+        return render_template("login.html", ident="",
+                               sso_enabled=sso.configured(), sso_label=sso.button_label())
 
     username = request.form.get("username", "").strip()
     password = request.form.get("password", "")
 
     def _login_again(message):
         flash(message, "error")
-        return render_template("login.html", ident=username)
+        return render_template("login.html", ident=username,
+                               sso_enabled=sso.configured(), sso_label=sso.button_label())
 
     rl_key = f"{request.remote_addr}:{username.lower()}"
     if _login_rate_limited(rl_key):
@@ -1201,6 +1204,104 @@ def login_2fa():
     _record_login_attempt(rl_key)
     flash("Invalid code. Try again, or use one of your backup codes.", "error")
     return render_template("login_2fa.html")
+
+
+# ---------------------------------------------------------------------------
+# Single sign-on (OIDC)
+# ---------------------------------------------------------------------------
+
+def _unique_username_from_email(email: str) -> str:
+    base = re.sub(r"[^a-z0-9._-]", "", (email.split("@")[0] or "").lower()) or "user"
+    candidate, i = base, 1
+    while User.query.filter_by(username=candidate).first():
+        i += 1
+        candidate = f"{base}{i}"
+    return candidate[:80]
+
+
+@app.route("/sso/login")
+def sso_login():
+    if current_user.is_authenticated:
+        return redirect(url_for("dashboard"))
+    if not sso.configured():
+        flash("Single sign-on isn't configured on this deployment.", "error")
+        return redirect(url_for("login"))
+    state = secrets.token_urlsafe(24)
+    session["sso_state"] = state
+    return redirect(sso.authorize_url(url_for("sso_callback", _external=True), state))
+
+
+@app.route("/sso/callback")
+def sso_callback():
+    """OIDC redirect target. Verifies state, exchanges the code, reads the
+    verified email from userinfo, and links / JIT-provisions the account.
+
+    Note: SSO is treated as strong authentication (the IdP performs its own
+    MFA), so it does not additionally trigger the app-level TOTP step."""
+    if current_user.is_authenticated:
+        return redirect(url_for("dashboard"))
+    if not sso.configured():
+        abort(404)
+
+    expected = session.pop("sso_state", None)
+    if not expected or not hmac.compare_digest(request.args.get("state", ""), expected):
+        flash("Sign-in could not be verified. Please try again.", "error")
+        return redirect(url_for("login"))
+    if request.args.get("error"):
+        flash("Single sign-on was canceled or denied.", "error")
+        return redirect(url_for("login"))
+    code = request.args.get("code", "")
+    if not code:
+        return redirect(url_for("login"))
+
+    try:
+        token = sso.exchange_code(code, url_for("sso_callback", _external=True))
+        access = token.get("access_token")
+        if not access:
+            raise RuntimeError("no access token in IdP response")
+        info = sso.fetch_userinfo(access)
+    except Exception:
+        app.logger.warning("SSO code exchange / userinfo failed", exc_info=True)
+        flash("Single sign-on failed. Please try again or use your password.", "error")
+        return redirect(url_for("login"))
+
+    email = (info.get("email") or "").strip()
+    res = sso.resolve(email, info.get("email_verified"))
+
+    if res.status == "unverified":
+        flash("Your identity provider hasn't verified that email address, so we can't sign you in.", "error")
+        return redirect(url_for("login"))
+    if res.status == "deactivated":
+        flash("This account has been deactivated. Contact your workspace admin.", "error")
+        return redirect(url_for("login"))
+    if res.status == "no_account":
+        flash("No workspace is set up for your email domain. Ask a workspace admin to invite you first.", "error")
+        return redirect(url_for("login"))
+
+    if res.status == "jit":
+        ok, _msg = billing.can_add_seat(res.org.id)
+        if not ok:
+            flash("Your team has reached its seat limit — ask an admin to upgrade or free a seat.", "error")
+            return redirect(url_for("login"))
+        user = User(
+            username=_unique_username_from_email(email),
+            email=email,
+            display_name=(info.get("name") or "").strip(),
+            org_id=res.org.id,
+            role="proposal",
+            email_verified=True,
+        )
+        user.set_password(secrets.token_urlsafe(32))  # unusable password — SSO only
+        db.session.add(user)
+        db.session.commit()
+        _log_activity_for(user, "sso_provision", f"Provisioned via SSO into {res.org.name}")
+    else:
+        user = res.user
+
+    session.permanent = True
+    login_user(user)
+    _log_activity_for(user, "login", "Signed in via SSO")
+    return redirect(url_for("dashboard"))
 
 
 # ---------------------------------------------------------------------------
@@ -6633,6 +6734,7 @@ def admin_panel():
         "admin.html",
         users=users,
         org=org,
+        sso_configured=sso.configured(),
         pending_invitations=pending_invitations,
         user_stats=user_stats,
         company_stats=company_stats,
@@ -6741,6 +6843,36 @@ def revoke_invitation(invite_id):
     db.session.commit()
     flash(f"Invitation for {inv.email} revoked.", "success")
     return redirect(url_for("admin_panel"))
+
+
+@app.route("/admin/sso", methods=["POST"])
+@login_required
+def update_sso_domain():
+    """Claim an email domain for this workspace so its users sign in via the
+    org's IdP, optionally auto-provisioning first-time members (JIT)."""
+    if not current_user.is_admin or not current_user.org_id:
+        abort(403)
+    org = db.session.get(Organization, current_user.org_id)
+    domain = request.form.get("sso_domain", "").strip().lower().lstrip("@")
+    if domain and (
+        "." not in domain or "@" in domain or "/" in domain or " " in domain
+    ):
+        flash("Enter a bare domain like acme.com.", "error")
+        return redirect(url_for("admin_panel") + "#sso")
+    if domain:
+        clash = Organization.query.filter(
+            db.func.lower(Organization.sso_domain) == domain,
+            Organization.id != org.id,
+        ).first()
+        if clash:
+            flash("That domain is already claimed by another workspace.", "error")
+            return redirect(url_for("admin_panel") + "#sso")
+    org.sso_domain = domain
+    org.sso_jit = bool(request.form.get("sso_jit"))
+    db.session.commit()
+    _log_activity("sso_config", f"Set SSO domain to {domain or '(none)'}")
+    flash("Single sign-on settings saved.", "success")
+    return redirect(url_for("admin_panel") + "#sso")
 
 
 @app.route("/admin/integrations", methods=["POST"])

--- a/billing.py
+++ b/billing.py
@@ -113,12 +113,42 @@ def plan_for(org) -> dict:
     return PLANS.get((org.plan if org else "free") or "free", PLANS["free"])
 
 
+def trial_active(org) -> bool:
+    """True while a free-plan org's signup trial window is still open.
+    trial_ends_at is stamped at workspace creation (14 days); orgs that
+    predate trials (NULL) and paid orgs never count as trialing."""
+    if not org or not getattr(org, "trial_ends_at", None):
+        return False
+    if (org.plan or "free") != "free":
+        return False
+    end = org.trial_ends_at
+    if end.tzinfo is None:
+        end = end.replace(tzinfo=timezone.utc)
+    return end > datetime.now(timezone.utc)
+
+
+def trial_days_left(org) -> int:
+    """Whole days remaining in the trial (0 when inactive/expired)."""
+    if not trial_active(org):
+        return 0
+    end = org.trial_ends_at
+    if end.tzinfo is None:
+        end = end.replace(tzinfo=timezone.utc)
+    return max(int((end - datetime.now(timezone.utc)).total_seconds() // 86400), 0)
+
+
 def effective_plan(org) -> dict:
-    """The plan whose LIMITS currently apply. A paid org that is delinquent
-    (past_due / unpaid) is soft-locked to free-tier limits until its payment
-    recovers; plan_for() still reports the nominal plan for the billing page."""
+    """The plan whose LIMITS currently apply.
+
+    - A paid org that is delinquent (past_due / unpaid) is soft-locked to
+      free-tier limits until its payment recovers.
+    - A free org inside its 14-day signup trial gets PRO limits — the trial
+      field was previously stamped but never enforced anywhere.
+    plan_for() still reports the nominal plan for the billing page."""
     if org and (getattr(org, "billing_status", "") or "") in _DELINQUENT_STATUSES:
         return PLANS["free"]
+    if trial_active(org):
+        return PLANS["pro"]
     return plan_for(org)
 
 

--- a/billing.py
+++ b/billing.py
@@ -132,22 +132,28 @@ def _month_key(dt=None) -> str:
 
 
 def generations_this_month(org_id) -> int:
-    """Count generations for the org in the current calendar month.
+    """Count AI proposal generations for the org in the current calendar month.
 
-    Counts queued + running + done (everything except failed), keyed on
-    created_at, so in-flight jobs count against the limit too. This closes the
-    burst/parallel bypass where only completed jobs were counted, letting a user
-    enqueue many generations before any finished."""
-    from models import BackgroundJob
+    Counts in-flight jobs (queued/running — closes the burst/parallel bypass
+    where many generations could be enqueued before any finished) PLUS
+    proposals actually produced. A run that finished WITHOUT producing a
+    proposal — the AI stopped to ask clarification questions, or the job
+    failed — no longer consumes quota, so answering questions and regenerating
+    doesn't burn a second credit for the same proposal attempt."""
+    from models import BackgroundJob, Project, Proposal
     start = datetime.now(timezone.utc).replace(day=1, hour=0, minute=0, second=0, microsecond=0)
-    return (
-        BackgroundJob.query.filter(
-            BackgroundJob.org_id == org_id,
-            BackgroundJob.kind == "generate_proposal",
-            BackgroundJob.status.in_(("queued", "running", "done")),
-            BackgroundJob.created_at >= start,
-        ).count()
+    inflight = BackgroundJob.query.filter(
+        BackgroundJob.org_id == org_id,
+        BackgroundJob.kind == "generate_proposal",
+        BackgroundJob.status.in_(("queued", "running")),
+        BackgroundJob.created_at >= start,
+    ).count()
+    produced = (
+        Proposal.query.join(Project, Proposal.project_id == Project.id)
+        .filter(Project.org_id == org_id, Proposal.generated_at >= start)
+        .count()
     )
+    return inflight + produced
 
 
 def seats_used(org_id) -> int:

--- a/billing.py
+++ b/billing.py
@@ -157,8 +157,11 @@ def generations_this_month(org_id) -> int:
 
 
 def seats_used(org_id) -> int:
+    """Active members only — deactivated (offboarded) users free their seat."""
     from models import User
-    return User.query.filter_by(org_id=org_id).count()
+    return User.query.filter(
+        User.org_id == org_id, User.is_active.isnot(False)
+    ).count()
 
 
 def check_generation(org_id) -> tuple[bool, str]:

--- a/document_parser.py
+++ b/document_parser.py
@@ -11,7 +11,9 @@ from config.settings import VERTICALS
 def parse_document(file_path: str) -> str:
     """Parse a document file and return its text content.
 
-    Supports PDF, DOCX, and plain text formats.
+    Supports PDF, DOCX, plain text, and Excel formats. (Excel matters because
+    RFQs frequently arrive as bid forms / pricing schedules in .xlsx — the
+    upload UI advertises it, so silently skipping it would drop scope.)
     """
     path = Path(file_path)
     suffix = path.suffix.lower()
@@ -20,8 +22,11 @@ def parse_document(file_path: str) -> str:
         return _parse_pdf(path)
     elif suffix in (".docx", ".doc"):
         return _parse_docx(path)
-    elif suffix in (".txt", ".md"):
-        return path.read_text(encoding="utf-8")
+    elif suffix in (".txt", ".md", ".csv"):
+        return path.read_text(encoding="utf-8", errors="replace")
+    elif suffix in (".xlsx", ".xls"):
+        from rate_sheet_parser import parse_rate_sheet
+        return parse_rate_sheet(str(path)).get("raw_text", "")
     else:
         raise ValueError(f"Unsupported file format: {suffix}")
 

--- a/document_parser.py
+++ b/document_parser.py
@@ -8,18 +8,32 @@ import PyPDF2
 from config.settings import VERTICALS
 
 
-def parse_document(file_path: str) -> str:
+def parse_document(file_path: str, ocr: bool = False) -> str:
     """Parse a document file and return its text content.
 
     Supports PDF, DOCX, plain text, and Excel formats. (Excel matters because
     RFQs frequently arrive as bid forms / pricing schedules in .xlsx — the
     upload UI advertises it, so silently skipping it would drop scope.)
+
+    When ``ocr=True`` and OCR is available, a PDF whose embedded text is sparse
+    (a scan) gets an OCR pass, and image files are OCR'd directly. OCR is slow,
+    so callers pass ``ocr=True`` only from background jobs — never the request
+    path.
     """
     path = Path(file_path)
     suffix = path.suffix.lower()
 
     if suffix == ".pdf":
-        return _parse_pdf(path)
+        text = _parse_pdf(path)
+        if ocr and len(text.strip()) < 100:
+            try:
+                import ocr as _ocr
+                ocr_text = _ocr.pdf_text(str(path))
+                if len(ocr_text.strip()) > len(text.strip()):
+                    text = ocr_text
+            except Exception:
+                pass
+        return text
     elif suffix in (".docx", ".doc"):
         return _parse_docx(path)
     elif suffix in (".txt", ".md", ".csv"):
@@ -27,6 +41,9 @@ def parse_document(file_path: str) -> str:
     elif suffix in (".xlsx", ".xls"):
         from rate_sheet_parser import parse_rate_sheet
         return parse_rate_sheet(str(path)).get("raw_text", "")
+    elif ocr and suffix in (".png", ".jpg", ".jpeg", ".tif", ".tiff", ".bmp", ".webp", ".gif"):
+        import ocr as _ocr
+        return _ocr.image_text(str(path))
     else:
         raise ValueError(f"Unsupported file format: {suffix}")
 

--- a/htmlsafe.py
+++ b/htmlsafe.py
@@ -14,6 +14,9 @@ _ALLOWED_TAGS = {
     "p", "br", "hr", "div", "span", "blockquote", "pre", "code",
     "h1", "h2", "h3", "h4", "h5", "h6",
     "strong", "em", "b", "i", "u", "s", "sub", "sup", "mark", "small",
+    # Redline view wraps diffs in <ins>/<del>; stripping them silently mashed
+    # old and new text together with no visual distinction.
+    "ins", "del",
     "ul", "ol", "li", "dl", "dt", "dd",
     "table", "thead", "tbody", "tfoot", "tr", "th", "td", "caption",
     "colgroup", "col",

--- a/jobs.py
+++ b/jobs.py
@@ -118,6 +118,11 @@ def _run_job(job_id: str):
         payload = json.loads(job.payload or "{}")
         result = handler(payload, job) or {}
         job = db.session.get(BackgroundJob, job_id)
+        if job.status == "canceled":
+            # User canceled while the handler ran. The work (and any LLM
+            # tokens) already happened, but the result is discarded and the
+            # job never counts as done.
+            return
         job.status = "done"
         job.result = json.dumps(result)
         job.finished_at = datetime.now(timezone.utc)
@@ -126,6 +131,8 @@ def _run_job(job_id: str):
         logger.error("Job %s (%s) failed:\n%s", job_id, job.kind, traceback.format_exc())
         db.session.rollback()
         job = db.session.get(BackgroundJob, job_id)
+        if job.status == "canceled":
+            return
         job.status = "failed"
         job.error = str(e)
         job.finished_at = datetime.now(timezone.utc)

--- a/migrations.py
+++ b/migrations.py
@@ -104,6 +104,19 @@ _INDEX_MIGRATIONS: list[tuple[str, str, str]] = [
     ("ix_background_jobs_org_id", "background_jobs", "org_id"),
     ("ix_background_jobs_status", "background_jobs", "status"),
     ("ix_background_jobs_created_at", "background_jobs", "created_at"),
+    # P2 hot-path indexes (list pages, dashboard focus list, generation context)
+    ("ix_revision_requests_proposal_id", "revision_requests", "proposal_id, status"),
+    ("ix_proposal_questions_project_status", "proposal_questions", "project_id, status"),
+    ("ix_scope_items_scope_id", "scope_items", "scope_id"),
+    ("ix_proposal_reviewers_user_id", "proposal_reviewers", "user_id"),
+    ("ix_proposal_shares_proposal_id", "proposal_shares", "proposal_id"),
+    ("ix_notifications_user_read", "notifications", "user_id, is_read"),
+    ("ix_user_rate_sheets_org_id", "user_rate_sheets", "org_id"),
+    ("ix_user_vertical_templates_org_id", "user_vertical_templates", "org_id"),
+    ("ix_staff_roles_org_id", "staff_roles", "org_id"),
+    ("ix_equipment_items_org_id", "equipment_items", "org_id"),
+    ("ix_travel_expense_rates_org_id", "travel_expense_rates", "org_id"),
+    ("ix_company_standards_org_id", "company_standards", "org_id"),
 ]
 
 # Tables that carry a per-user org_id needing backfill from the owning user.

--- a/migrations.py
+++ b/migrations.py
@@ -84,6 +84,9 @@ _COLUMN_MIGRATIONS: list[tuple[str, str, str]] = [
     ("organizations", "logo_show_on_cover", "BOOLEAN DEFAULT TRUE"),
     # P1: parse receipt captured at upload (NULL = never checked)
     ("project_documents", "text_chars", "INTEGER"),
+    # P3: typed-name acceptance on the customer portal
+    ("proposal_shares", "decided_by_name", "VARCHAR(200) DEFAULT ''"),
+    ("proposal_shares", "decided_by_title", "VARCHAR(200) DEFAULT ''"),
 ]
 
 # Indexes on hot filter / foreign-key columns. CREATE INDEX IF NOT EXISTS is

--- a/migrations.py
+++ b/migrations.py
@@ -91,6 +91,9 @@ _COLUMN_MIGRATIONS: list[tuple[str, str, str]] = [
     ("users", "totp_secret_encrypted", "TEXT DEFAULT ''"),
     ("users", "totp_enabled", "BOOLEAN DEFAULT FALSE"),
     ("users", "totp_backup_codes", "TEXT DEFAULT ''"),
+    # SSO: per-org domain claim + JIT provisioning
+    ("organizations", "sso_domain", "VARCHAR(200) DEFAULT ''"),
+    ("organizations", "sso_jit", "BOOLEAN DEFAULT FALSE"),
 ]
 
 # Indexes on hot filter / foreign-key columns. CREATE INDEX IF NOT EXISTS is
@@ -124,6 +127,7 @@ _INDEX_MIGRATIONS: list[tuple[str, str, str]] = [
     ("ix_equipment_items_org_id", "equipment_items", "org_id"),
     ("ix_travel_expense_rates_org_id", "travel_expense_rates", "org_id"),
     ("ix_company_standards_org_id", "company_standards", "org_id"),
+    ("ix_organizations_sso_domain", "organizations", "sso_domain"),
 ]
 
 # Tables that carry a per-user org_id needing backfill from the owning user.

--- a/migrations.py
+++ b/migrations.py
@@ -74,6 +74,16 @@ _COLUMN_MIGRATIONS: list[tuple[str, str, str]] = [
     ("users", "lockout_until", "TIMESTAMP"),
     # Platform-admin dashboard
     ("users", "platform_owner", "BOOLEAN DEFAULT FALSE"),
+    # P1 hardening: member offboarding
+    ("users", "is_active", "BOOLEAN DEFAULT TRUE"),
+    # P1: org-level branding (proposals branded per workspace, not per user)
+    ("organizations", "logo_path", "VARCHAR(1000) DEFAULT ''"),
+    ("organizations", "logo_original_name", "VARCHAR(500) DEFAULT ''"),
+    ("organizations", "logo_use_in_proposals", "BOOLEAN DEFAULT TRUE"),
+    ("organizations", "logo_placement", "VARCHAR(20) DEFAULT 'top_left'"),
+    ("organizations", "logo_show_on_cover", "BOOLEAN DEFAULT TRUE"),
+    # P1: parse receipt captured at upload (NULL = never checked)
+    ("project_documents", "text_chars", "INTEGER"),
 ]
 
 # Indexes on hot filter / foreign-key columns. CREATE INDEX IF NOT EXISTS is
@@ -194,6 +204,71 @@ def _backfill_organizations():
     db.session.commit()
 
 
+def _backfill_active_flag():
+    """Rows that predate users.is_active get NULL on some engines — a NULL is
+    falsy to flask-login and would lock every legacy user out. Force TRUE."""
+    db.session.execute(text("UPDATE users SET is_active = TRUE WHERE is_active IS NULL"))
+    db.session.commit()
+
+
+def _backfill_org_branding():
+    """Move per-user branding up to the organization (one-time).
+
+    Historically the logo/company identity lived on User rows, so proposals
+    were branded by whoever owned the project. Copy the best candidate (an
+    admin's logo, else any member's) onto the org so branding is consistent
+    workspace-wide. User columns are left in place but are no longer read."""
+    orgs = Organization.query.filter(
+        db.or_(Organization.logo_path.is_(None), Organization.logo_path == "")
+    ).all()
+    changed = False
+    for org in orgs:
+        donor = (
+            User.query.filter(User.org_id == org.id,
+                              User.company_logo_path.isnot(None),
+                              User.company_logo_path != "")
+            .order_by(User.is_admin.desc(), User.created_at.asc())
+            .first()
+        )
+        if not donor:
+            continue
+        org.logo_path = donor.company_logo_path
+        org.logo_original_name = donor.company_logo_original_name or ""
+        org.logo_use_in_proposals = bool(donor.company_logo_use_in_proposals)
+        org.logo_placement = donor.company_logo_placement or "top_left"
+        org.logo_show_on_cover = bool(donor.company_logo_show_on_cover)
+        changed = True
+
+    # Orgs still carrying the auto-generated "<name>'s Workspace" label pick up
+    # the admin's company name for proposal branding, if one was ever set.
+    for org in Organization.query.filter(Organization.name.like("%'s Workspace")).all():
+        admin = (User.query.filter(User.org_id == org.id, User.is_admin.is_(True))
+                 .order_by(User.created_at.asc()).first())
+        if admin and (admin.company_name or "").strip():
+            org.name = admin.company_name.strip()
+            changed = True
+    if changed:
+        db.session.commit()
+
+
+def _add_unique_email_index():
+    """Case-insensitive unique index on users.email (P1: duplicate emails break
+    password reset and verification). Best-effort: if legacy duplicates exist
+    the index can't be created — log loudly so the operator can dedupe, while
+    the app-level uniqueness checks still stop NEW duplicates."""
+    try:
+        db.session.execute(text(
+            "CREATE UNIQUE INDEX IF NOT EXISTS ix_users_email_lower ON users (lower(email))"
+        ))
+        db.session.commit()
+    except Exception:
+        db.session.rollback()
+        logger.exception(
+            "Migration: could not create unique email index — duplicate emails "
+            "likely exist in users; dedupe them manually."
+        )
+
+
 def ensure_schema():
     """Create tables, add missing columns, and run data backfills.
     Must be called inside an app context."""
@@ -207,3 +282,6 @@ def ensure_schema():
     _add_missing_columns()
     _add_indexes()
     _backfill_organizations()
+    _backfill_active_flag()
+    _backfill_org_branding()
+    _add_unique_email_index()

--- a/migrations.py
+++ b/migrations.py
@@ -87,6 +87,10 @@ _COLUMN_MIGRATIONS: list[tuple[str, str, str]] = [
     # P3: typed-name acceptance on the customer portal
     ("proposal_shares", "decided_by_name", "VARCHAR(200) DEFAULT ''"),
     ("proposal_shares", "decided_by_title", "VARCHAR(200) DEFAULT ''"),
+    # Two-factor auth (TOTP)
+    ("users", "totp_secret_encrypted", "TEXT DEFAULT ''"),
+    ("users", "totp_enabled", "BOOLEAN DEFAULT FALSE"),
+    ("users", "totp_backup_codes", "TEXT DEFAULT ''"),
 ]
 
 # Indexes on hot filter / foreign-key columns. CREATE INDEX IF NOT EXISTS is

--- a/models.py
+++ b/models.py
@@ -38,6 +38,14 @@ class Organization(db.Model):
     slack_webhook_url = db.Column(db.String(1000), default="")
     outbound_webhook_url = db.Column(db.String(1000), default="")
 
+    # Workspace branding (org-level — proposals are branded per ORG, not per
+    # user, so every member's generations carry the same identity)
+    logo_path = db.Column(db.String(1000), default="")
+    logo_original_name = db.Column(db.String(500), default="")
+    logo_use_in_proposals = db.Column(db.Boolean, default=True)
+    logo_placement = db.Column(db.String(20), default="top_left")  # top_left, center
+    logo_show_on_cover = db.Column(db.Boolean, default=True)
+
     members = db.relationship("User", backref="organization", lazy="dynamic",
                               foreign_keys="User.org_id")
 
@@ -114,6 +122,9 @@ class User(UserMixin, db.Model):
     is_admin = db.Column(db.Boolean, default=False)
     role = db.Column(db.String(20), default="proposal")  # admin, sales, proposal
     email_verified = db.Column(db.Boolean, default=False)
+    # Deactivated members can't sign in and don't hold a seat (offboarding).
+    # Shadows flask-login's UserMixin.is_active property with a real column.
+    is_active = db.Column(db.Boolean, default=True, nullable=False)
     created_at = db.Column(db.DateTime, default=_utcnow)
 
     # Platform ownership — the SaaS operator, NOT a tenant admin. Grants access
@@ -202,6 +213,9 @@ class ProjectDocument(db.Model):
     file_size = db.Column(db.Integer, default=0)
     uploaded_at = db.Column(db.DateTime, default=_utcnow)
     is_reference = db.Column(db.Boolean, default=False)  # True = available across all projects
+    # Characters of machine-readable text extracted at upload time. 0 = the
+    # file parsed but yielded no text (e.g. a scanned PDF); NULL = not checked.
+    text_chars = db.Column(db.Integer, nullable=True)
     notes = db.Column(db.Text, default="")
     version_group = db.Column(db.String(32), default="")  # Groups document versions together
     version_label = db.Column(db.String(100), default="")  # e.g., "Addendum 1", "Rev B"

--- a/models.py
+++ b/models.py
@@ -38,6 +38,12 @@ class Organization(db.Model):
     slack_webhook_url = db.Column(db.String(1000), default="")
     outbound_webhook_url = db.Column(db.String(1000), default="")
 
+    # SSO: the email domain this workspace claims (e.g. "acme.com"). Users at
+    # that domain sign in via the configured OIDC IdP; sso_jit auto-provisions
+    # first-time members into this org.
+    sso_domain = db.Column(db.String(200), default="")
+    sso_jit = db.Column(db.Boolean, default=False, nullable=False)
+
     # Workspace branding (org-level — proposals are branded per ORG, not per
     # user, so every member's generations carry the same identity)
     logo_path = db.Column(db.String(1000), default="")

--- a/models.py
+++ b/models.py
@@ -816,9 +816,12 @@ class ProposalShare(db.Model):
     view_count = db.Column(db.Integer, default=0)
     last_viewed_at = db.Column(db.DateTime, nullable=True)
 
-    # Customer's decision recorded through the portal
+    # Customer's decision recorded through the portal. Name/title typed by the
+    # decider give the acceptance a lightweight signature record.
     decision = db.Column(db.String(20), default="")  # accepted, declined
     decision_note = db.Column(db.Text, default="")
+    decided_by_name = db.Column(db.String(200), default="")
+    decided_by_title = db.Column(db.String(200), default="")
     decided_at = db.Column(db.DateTime, nullable=True)
 
     revoked_at = db.Column(db.DateTime, nullable=True)

--- a/models.py
+++ b/models.py
@@ -136,6 +136,13 @@ class User(UserMixin, db.Model):
     failed_login_count = db.Column(db.Integer, default=0)
     lockout_until = db.Column(db.DateTime, nullable=True)
 
+    # Two-factor auth (TOTP). Secret is encrypted at rest; backup codes are a
+    # JSON array of single-use SHA-256 hashes. totp_enabled gates the login
+    # second step (an unconfirmed enrollment stores a secret but stays False).
+    totp_secret_encrypted = db.Column(db.Text, default="")
+    totp_enabled = db.Column(db.Boolean, default=False, nullable=False)
+    totp_backup_codes = db.Column(db.Text, default="")
+
     # LLM settings — per-user overrides
     llm_provider = db.Column(db.String(50), default="anthropic")
     llm_model = db.Column(db.String(100), default="claude-opus-4-8")

--- a/ocr.py
+++ b/ocr.py
@@ -1,0 +1,152 @@
+"""Optical character recognition for scanned (image-only) PDFs.
+
+Many RFPs arrive as scans — a PDF whose "pages" are just images, so the normal
+text extractor returns almost nothing. When OCR is available we render each
+page to an image (via pypdfium2, a self-contained wheel — no poppler/system
+renderer needed) and run Tesseract over it.
+
+Everything here is BEST-EFFORT and degrades gracefully: if the Tesseract binary
+or the Python wrappers aren't installed, `available()` is False and callers
+fall back to plain text extraction. OCR only runs inside background jobs
+(generation / scope / estimate), never in the request path, because it is slow
+(~1-2s per page).
+
+Results are cached to a sidecar file next to the source (``<path>.ocr.txt``)
+and mirrored to object storage, so a scanned document is OCR'd once, not once
+per scope-draft + generate + estimate.
+"""
+
+import logging
+import os
+from functools import lru_cache
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# Kill switch + safety caps (env-overridable). A very long scanned PDF could
+# otherwise tie a worker up for minutes; we cap pages and log truncation.
+_ENABLED = os.getenv("OCR_ENABLED", "true").lower() == "true"
+_MAX_PAGES = int(os.getenv("OCR_MAX_PAGES", "50"))
+_DPI = int(os.getenv("OCR_DPI", "200"))
+
+# Below this many characters, a PDF's embedded text is treated as "scanned"
+# and worth an OCR pass.
+SPARSE_TEXT_THRESHOLD = 100
+
+_IMAGE_SUFFIXES = {".png", ".jpg", ".jpeg", ".tif", ".tiff", ".bmp", ".webp", ".gif"}
+
+
+@lru_cache(maxsize=1)
+def available() -> bool:
+    """True only if OCR can actually run (wrappers importable + Tesseract binary
+    present). Cached — the answer doesn't change during a process's life."""
+    if not _ENABLED:
+        return False
+    try:
+        import pypdfium2  # noqa: F401
+        import pytesseract
+    except Exception:
+        return False
+    try:
+        pytesseract.get_tesseract_version()
+        return True
+    except Exception:
+        logger.info("OCR wrappers present but the Tesseract binary is not runnable.")
+        return False
+
+
+def _sidecar(path) -> Path:
+    return Path(str(path) + ".ocr.txt")
+
+
+def _read_cache(path) -> str | None:
+    sc = _sidecar(path)
+    try:
+        import storage
+        storage.ensure_local(sc)
+    except Exception:
+        pass
+    if sc.exists():
+        try:
+            return sc.read_text(encoding="utf-8")
+        except Exception:
+            return None
+    return None
+
+
+def _write_cache(path, text: str):
+    sc = _sidecar(path)
+    try:
+        sc.write_text(text, encoding="utf-8")
+        import storage
+        storage.sync_up(sc)
+    except Exception:
+        logger.warning("Could not cache OCR output for %s", path, exc_info=True)
+
+
+def _ocr_pil(image) -> str:
+    import pytesseract
+    try:
+        return pytesseract.image_to_string(image) or ""
+    except Exception:
+        logger.warning("Tesseract failed on a page", exc_info=True)
+        return ""
+
+
+def image_text(path) -> str:
+    """OCR a single image file. Returns '' on any failure."""
+    if not available():
+        return ""
+    try:
+        from PIL import Image
+        with Image.open(path) as img:
+            return _ocr_pil(img).strip()
+    except Exception:
+        logger.warning("OCR of image %s failed", path, exc_info=True)
+        return ""
+
+
+def pdf_text(path, max_pages: int = None) -> str:
+    """OCR a scanned PDF page by page. Cached to a sidecar. Returns '' if OCR is
+    unavailable or nothing could be recognized."""
+    if not available():
+        return ""
+    cached = _read_cache(path)
+    if cached is not None:
+        return cached
+
+    max_pages = max_pages or _MAX_PAGES
+    text = ""
+    try:
+        import pypdfium2 as pdfium
+        pdf = pdfium.PdfDocument(str(path))
+        try:
+            n = len(pdf)
+            scale = _DPI / 72.0
+            parts = []
+            for i in range(min(n, max_pages)):
+                page = pdf[i]
+                try:
+                    bitmap = page.render(scale=scale)
+                    pil = bitmap.to_pil()
+                    parts.append(_ocr_pil(pil))
+                finally:
+                    page.close()
+            if n > max_pages:
+                logger.warning("OCR truncated %s at %d of %d pages", path, max_pages, n)
+                parts.append(f"\n[OCR truncated after {max_pages} of {n} pages]")
+            text = "\n\n".join(p for p in parts if p).strip()
+        finally:
+            pdf.close()
+    except Exception:
+        logger.warning("OCR of PDF %s failed", path, exc_info=True)
+        return ""
+
+    # Cache even an empty result would re-trigger OCR forever; only cache hits.
+    if text:
+        _write_cache(path, text)
+    return text
+
+
+def is_image(path) -> bool:
+    return Path(str(path)).suffix.lower() in _IMAGE_SUFFIXES

--- a/platform_admin.py
+++ b/platform_admin.py
@@ -399,6 +399,9 @@ _CONTROL_GROUPS = [
     ("email", "Email (SMTP)",
      ["smtp_host", "smtp_port", "smtp_user", "smtp_password", "smtp_use_tls",
       "mail_from", "mail_from_name"]),
+    ("sso", "Single sign-on (OIDC)",
+     ["oidc_client_id", "oidc_client_secret", "oidc_auth_url", "oidc_token_url",
+      "oidc_userinfo_url", "oidc_scopes", "oidc_button_label"]),
 ]
 
 

--- a/platform_admin.py
+++ b/platform_admin.py
@@ -102,7 +102,7 @@ def login():
             return render_template("platform/login.html")
 
         user = User.query.filter(
-            db.or_(User.email.ilike(ident), User.username == ident)
+            db.or_(db.func.lower(User.email) == ident.lower(), User.username == ident)
         ).first()
 
         now = datetime.now(timezone.utc)
@@ -457,7 +457,7 @@ def controls_settings():
 def controls_owner():
     email = request.form.get("email", "").strip().lower()
     action = request.form.get("action", "grant")
-    user = User.query.filter(User.email.ilike(email)).first() if email else None
+    user = User.query.filter(db.func.lower(User.email) == email).first() if email else None
     if not user:
         flash("No user found with that email.", "error")
         return redirect(url_for("platform_admin.controls"))

--- a/platform_admin.py
+++ b/platform_admin.py
@@ -69,21 +69,66 @@ def _since(days: int):
 # Auth
 # ---------------------------------------------------------------------------
 
+# Brute-force protection for the operator login — the highest-value credential
+# in the system. In-process per-IP window plus the same DB-backed per-account
+# lockout the tenant login uses (survives multiple gunicorn workers).
+_PA_ATTEMPTS: dict[str, list[float]] = {}
+_PA_MAX_ATTEMPTS = 8
+_PA_WINDOW_SECONDS = 300
+_PA_LOCK_THRESHOLD = 10
+_PA_LOCK_SECONDS = 15 * 60
+
+
+def _pa_rate_limited(key: str) -> bool:
+    import time
+    now = time.time()
+    attempts = [t for t in _PA_ATTEMPTS.get(key, []) if now - t < _PA_WINDOW_SECONDS]
+    _PA_ATTEMPTS[key] = attempts
+    return len(attempts) >= _PA_MAX_ATTEMPTS
+
+
 @bp.route("/login", methods=["GET", "POST"])
 def login():
     if is_platform_owner(current_user):
         return redirect(url_for("platform_admin.overview"))
     if request.method == "POST":
+        import time
         ident = request.form.get("email", "").strip()
         password = request.form.get("password", "")
+
+        rl_key = f"{request.remote_addr}:{ident.lower()}"
+        if _pa_rate_limited(rl_key):
+            flash("Too many attempts. Please wait a few minutes and try again.", "error")
+            return render_template("platform/login.html")
+
         user = User.query.filter(
             db.or_(User.email.ilike(ident), User.username == ident)
         ).first()
+
+        now = datetime.now(timezone.utc)
+        if user and user.lockout_until:
+            lock = user.lockout_until if user.lockout_until.tzinfo else user.lockout_until.replace(tzinfo=timezone.utc)
+            if lock > now:
+                flash("Invalid credentials.", "error")
+                return render_template("platform/login.html")
+
         # Same generic failure whether the credentials are wrong OR the account
         # simply isn't a platform owner — don't reveal who the owners are.
         if user and user.check_password(password) and is_platform_owner(user):
+            if user.failed_login_count or user.lockout_until:
+                user.failed_login_count = 0
+                user.lockout_until = None
+                db.session.commit()
             login_user(user)
             return redirect(url_for("platform_admin.overview"))
+
+        _PA_ATTEMPTS.setdefault(rl_key, []).append(time.time())
+        if user:
+            user.failed_login_count = (user.failed_login_count or 0) + 1
+            if user.failed_login_count >= _PA_LOCK_THRESHOLD:
+                user.lockout_until = now + timedelta(seconds=_PA_LOCK_SECONDS)
+                user.failed_login_count = 0
+            db.session.commit()
         flash("Invalid credentials.", "error")
     return render_template("platform/login.html")
 

--- a/platform_config.py
+++ b/platform_config.py
@@ -30,6 +30,14 @@ SETTINGS = {
     "smtp_use_tls":           ("SMTP_USE_TLS", False, "Use TLS (true/false)", "email"),
     "mail_from":              ("MAIL_FROM", False, "From address", "email"),
     "mail_from_name":         ("MAIL_FROM_NAME", False, "From name", "email"),
+    # SSO (OIDC)
+    "oidc_client_id":         ("OIDC_CLIENT_ID", False, "OIDC client ID", "sso"),
+    "oidc_client_secret":     ("OIDC_CLIENT_SECRET", True, "OIDC client secret", "sso"),
+    "oidc_auth_url":          ("OIDC_AUTH_URL", False, "OIDC authorization URL", "sso"),
+    "oidc_token_url":         ("OIDC_TOKEN_URL", False, "OIDC token URL", "sso"),
+    "oidc_userinfo_url":      ("OIDC_USERINFO_URL", False, "OIDC userinfo URL", "sso"),
+    "oidc_scopes":            ("OIDC_SCOPES", False, "OIDC scopes", "sso"),
+    "oidc_button_label":      ("OIDC_BUTTON_LABEL", False, "SSO button label", "sso"),
 }
 
 

--- a/proposal_agent.py
+++ b/proposal_agent.py
@@ -674,7 +674,8 @@ def generate_proposal(rfp_text: str, vertical: str = "auto",
                       past_corrections: list = None,
                       company_standards: list = None,
                       approved_scope: list = None,
-                      request_type: str = "") -> dict:
+                      request_type: str = "",
+                      include_global_boilerplate: bool = True) -> dict:
     """Generate a proposal from the given RFP/RFQ text.
 
     Args:
@@ -693,6 +694,11 @@ def generate_proposal(rfp_text: str, vertical: str = "auto",
         travel_data: List of travel expense rate dicts from user's settings.
         past_corrections: List of correction dicts from past human edits.
         company_standards: List of company standard dicts for auto-injection.
+        include_global_boilerplate: When False (hosted multi-tenant mode), the
+            install-level sample templates/reference documents and any vertical
+            company-boilerplate files are NOT injected into the prompt — they
+            describe a different company and would contaminate tenant output.
+            Self-hosted installs keep True (they customize those files).
 
     Returns:
         dict with proposal_markdown, action_items, confidence_score,
@@ -722,8 +728,23 @@ def generate_proposal(rfp_text: str, vertical: str = "auto",
 
     # Load resources
     vertical_resources = load_vertical_resources(vertical)
-    global_templates = load_templates(TEMPLATES_DIR)
-    global_references = load_reference_documents(REFERENCE_DIR)
+    if include_global_boilerplate:
+        global_templates = load_templates(TEMPLATES_DIR)
+        global_references = load_reference_documents(REFERENCE_DIR)
+    else:
+        # Hosted multi-tenant mode: only the org's own posture (templates,
+        # standards, rates — passed in by the caller) may describe the company.
+        # Vertical workflow + structural templates stay; company boilerplate
+        # files (e.g. verticals/*/templates/company_boilerplate.md) are dropped.
+        global_templates = {}
+        global_references = {}
+        vertical_resources = dict(vertical_resources)
+        vertical_resources["templates"] = {
+            name: content
+            for name, content in (vertical_resources.get("templates") or {}).items()
+            if "boilerplate" not in name.lower()
+        }
+        vertical_resources["reference_proposals"] = []
 
     # Build rate sheet context
     rate_sheet_text = ""

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,7 @@ boto3>=1.34.0
 stripe>=9.0.0
 xhtml2pdf>=0.2.11
 nh3>=0.2.15
+pypdfium2>=4.30.0
+pytesseract>=0.3.13
+pyotp>=2.9.0
+qrcode>=7.4.2

--- a/sso.py
+++ b/sso.py
@@ -1,0 +1,152 @@
+"""OIDC single sign-on (authorization-code flow).
+
+Provider-agnostic OpenID Connect: works with Google, Microsoft/Entra, Okta,
+Auth0, etc. The operator configures the endpoints + client credentials in
+Platform-Admin (or env). A workspace admin then "claims" an email domain
+(Organization.sso_domain) so users at that domain sign in via the IdP; with
+JIT provisioning on, first-time users are auto-added to that workspace.
+
+Security model:
+  - `state` (random, session-stored) defends the callback against CSRF.
+  - We require `email_verified == true` from the IdP before trusting an email.
+  - Users are matched to accounts by verified email; a deactivated account is
+    refused; an unknown email only creates an account when its domain is
+    claimed by an org with JIT enabled — SSO never silently mints a brand-new
+    workspace.
+  - All IdP URLs must be https.
+
+We use the access token against the userinfo endpoint rather than validating an
+id_token JWT ourselves: the userinfo response is trusted because it's fetched
+directly from the IdP over TLS with a freshly-issued access token.
+"""
+
+import json
+import logging
+import urllib.parse
+import urllib.request
+from collections import namedtuple
+
+logger = logging.getLogger(__name__)
+
+_TIMEOUT = 10
+
+Resolution = namedtuple("Resolution", ["status", "user", "org"])
+# status ∈ {"ok", "jit", "unverified", "deactivated", "no_account", "error"}
+
+
+def _cfg(key: str, default: str = "") -> str:
+    try:
+        import platform_config
+        return platform_config.get(key, default)
+    except Exception:
+        return default
+
+
+def client_id() -> str: return _cfg("oidc_client_id")
+def client_secret() -> str: return _cfg("oidc_client_secret")
+def auth_url() -> str: return _cfg("oidc_auth_url")
+def token_url() -> str: return _cfg("oidc_token_url")
+def userinfo_url() -> str: return _cfg("oidc_userinfo_url")
+def scopes() -> str: return _cfg("oidc_scopes", "openid email profile")
+def button_label() -> str: return _cfg("oidc_button_label", "Single sign-on (SSO)")
+
+
+def _all_https(*urls) -> bool:
+    return all((u or "").lower().startswith("https://") for u in urls)
+
+
+def configured() -> bool:
+    """True only if every required OIDC endpoint + credential is set and all
+    endpoints are https."""
+    parts = [client_id(), client_secret(), auth_url(), token_url(), userinfo_url()]
+    if not all(parts):
+        return False
+    return _all_https(auth_url(), token_url(), userinfo_url())
+
+
+def authorize_url(redirect_uri: str, state: str) -> str:
+    q = urllib.parse.urlencode({
+        "response_type": "code",
+        "client_id": client_id(),
+        "redirect_uri": redirect_uri,
+        "scope": scopes(),
+        "state": state,
+        "access_type": "offline",
+        "prompt": "select_account",
+    })
+    sep = "&" if "?" in auth_url() else "?"
+    return f"{auth_url()}{sep}{q}"
+
+
+def _post_form(url: str, data: dict) -> dict:
+    body = urllib.parse.urlencode(data).encode("utf-8")
+    req = urllib.request.Request(url, data=body, headers={
+        "Content-Type": "application/x-www-form-urlencoded",
+        "Accept": "application/json",
+    })
+    with urllib.request.urlopen(req, timeout=_TIMEOUT) as resp:
+        return json.loads(resp.read().decode("utf-8"))
+
+
+def _get_json(url: str, token: str) -> dict:
+    req = urllib.request.Request(url, headers={
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/json",
+    })
+    with urllib.request.urlopen(req, timeout=_TIMEOUT) as resp:
+        return json.loads(resp.read().decode("utf-8"))
+
+
+def exchange_code(code: str, redirect_uri: str) -> dict:
+    """Exchange an authorization code for tokens at the IdP token endpoint."""
+    return _post_form(token_url(), {
+        "grant_type": "authorization_code",
+        "code": code,
+        "redirect_uri": redirect_uri,
+        "client_id": client_id(),
+        "client_secret": client_secret(),
+    })
+
+
+def fetch_userinfo(access_token: str) -> dict:
+    return _get_json(userinfo_url(), access_token)
+
+
+def domain_of(email: str) -> str:
+    return (email or "").strip().lower().rsplit("@", 1)[-1] if "@" in (email or "") else ""
+
+
+def _truthy(v) -> bool:
+    return v is True or str(v).strip().lower() in ("true", "1", "yes")
+
+
+def resolve(email: str, email_verified) -> Resolution:
+    """Map a verified IdP identity onto a local account. PURE decision logic
+    (no HTTP) so every branch is unit-testable.
+
+    Returns a Resolution whose status tells the caller what to do:
+      ok          -> log `user` in
+      jit         -> create a member in `org`, then log in
+      unverified  -> refuse (email not verified by the IdP)
+      deactivated -> refuse (account offboarded)
+      no_account  -> refuse (no workspace claims this email's domain)
+    """
+    from models import Organization, User, db
+
+    email = (email or "").strip().lower()
+    if not email or not _truthy(email_verified):
+        return Resolution("unverified", None, None)
+
+    user = User.query.filter(db.func.lower(User.email) == email).first()
+    if user is not None:
+        if user.is_active is False:
+            return Resolution("deactivated", None, None)
+        return Resolution("ok", user, None)
+
+    domain = domain_of(email)
+    org = Organization.query.filter(
+        db.func.lower(Organization.sso_domain) == domain
+    ).first() if domain else None
+    if org and _truthy(org.sso_jit):
+        return Resolution("jit", None, org)
+    return Resolution("no_account", None, None)

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -3132,3 +3132,20 @@ summary:focus-visible,
     font-size: 13px;
     color: var(--ink-500);
 }
+
+/* Flash dismiss control (P3) */
+.flash { position: relative; padding-right: 38px; }
+.flash-close {
+    position: absolute;
+    top: 6px;
+    right: 8px;
+    border: 0;
+    background: none;
+    font-size: 18px;
+    line-height: 1;
+    cursor: pointer;
+    color: inherit;
+    opacity: 0.55;
+    padding: 4px;
+}
+.flash-close:hover { opacity: 1; }

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -3149,3 +3149,19 @@ summary:focus-visible,
     padding: 4px;
 }
 .flash-close:hover { opacity: 1; }
+
+/* Auth "or" divider (SSO on the login page) */
+.auth-divider {
+    display: flex;
+    align-items: center;
+    text-align: center;
+    color: var(--ink-300);
+    font-size: 12px;
+    margin: 16px 0;
+}
+.auth-divider::before, .auth-divider::after {
+    content: "";
+    flex: 1;
+    border-bottom: 1px solid var(--line);
+}
+.auth-divider span { padding: 0 12px; }

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -3074,3 +3074,61 @@ body {
 .ai-assist-group { display: inline-flex; align-items: center; gap: 4px; }
 .ai-assist-label { font-size: 12px; color: var(--sea-800, #0f6b6b); font-weight: 600; }
 .sample-banner { display: flex; align-items: center; justify-content: space-between; gap: 16px; flex-wrap: wrap; background: var(--sea-50, #f0f7f7); border-left: 3px solid var(--sea-800, #0f6b6b); }
+
+/* ============================================================
+   P2 Accessibility & pagination
+   ============================================================ */
+
+/* Keyboard focus: a clearly visible ring wherever focus lands. Overrides the
+   scattered `outline: none` on inputs (their border/box-shadow focus styles
+   remain for mouse focus; keyboard users always get the ring). */
+a:focus-visible,
+button:focus-visible,
+input:focus-visible,
+select:focus-visible,
+textarea:focus-visible,
+summary:focus-visible,
+[tabindex]:focus-visible {
+    outline: 2px solid var(--sea-500) !important;
+    outline-offset: 2px;
+}
+
+/* Skip link — first tab stop; visible only when focused */
+.skip-link {
+    position: absolute;
+    left: -9999px;
+    top: 0;
+    z-index: 2000;
+    padding: 10px 16px;
+    background: var(--sea-800);
+    color: #fff;
+    border-radius: 0 0 8px 0;
+    font-weight: 600;
+    text-decoration: none;
+}
+.skip-link:focus {
+    left: 0;
+}
+
+/* Honor reduced-motion preferences: stop spinners/transitions from animating */
+@media (prefers-reduced-motion: reduce) {
+    *, *::before, *::after {
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.01ms !important;
+        scroll-behavior: auto !important;
+    }
+}
+
+/* Pagination nav (proposals table, document library) */
+.pagination {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 12px;
+    margin-top: 14px;
+}
+.pagination-status {
+    font-size: 13px;
+    color: var(--ink-500);
+}

--- a/test_2fa.py
+++ b/test_2fa.py
@@ -1,0 +1,153 @@
+"""Tests for TOTP two-factor authentication: the helper module, enrollment,
+the login second-step gate, backup codes, and disable.
+
+Standalone runner: python test_2fa.py
+"""
+import os
+import sys
+
+os.environ['FLASK_SECRET_KEY'] = 'test-secret-key-12345'
+os.environ.pop('APP_ENV', None)
+
+import pyotp
+
+import crypto_util
+import twofa
+from app import app, db
+from models import Organization, User
+
+app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+app.config['TESTING'] = True
+
+passed = failed = 0
+
+
+def test(name, cond, detail=""):
+    global passed, failed
+    if cond:
+        passed += 1; print(f"  PASS: {name}")
+    else:
+        failed += 1; print(f"  FAIL: {name} - {detail}")
+
+
+def code_for(user):
+    secret = crypto_util.decrypt(user.totp_secret_encrypted)
+    return pyotp.TOTP(secret).now()
+
+
+with app.app_context():
+    db.drop_all(); db.create_all()
+
+    print("\n=== twofa helper module ===")
+    s = twofa.new_secret()
+    test("new_secret is base32-ish", isinstance(s, str) and len(s) >= 16)
+    test("verify_code accepts a live code", twofa.verify_code(s, pyotp.TOTP(s).now()))
+    test("verify_code rejects a bad code", not twofa.verify_code(s, "000000"))
+    test("verify_code rejects non-digits", not twofa.verify_code(s, "abcdef"))
+
+    plain, hashes = twofa.generate_backup_codes()
+    test("10 backup codes generated", len(plain) == 10)
+    test("backup codes stored hashed (not plaintext)",
+         all(p not in hashes for p in plain))
+    ok, new_json = twofa.consume_backup_code(hashes, plain[0])
+    test("valid backup code consumes", ok and twofa.backup_codes_remaining(new_json) == 9)
+    ok2, _ = twofa.consume_backup_code(new_json, plain[0])
+    test("consumed backup code can't be reused", not ok2)
+    test("backup code matching is case/dash-insensitive",
+         twofa.hash_backup_code(plain[1].upper().replace('-', '')) ==
+         twofa.hash_backup_code(plain[1]))
+
+    # --- Enrollment via the app -------------------------------------------
+    c = app.test_client()
+    c.post('/signup', data={'username': 'tia', 'email': 'tia@corp.com',
+                            'password': 'password123', 'company_name': 'TiaCorp'})
+    tia = User.query.filter_by(username='tia').first()
+    tia.email_verified = True
+    db.session.commit()
+
+    print("\n=== Enrollment ===")
+    r = c.post('/settings/2fa/start')
+    db.session.refresh(tia)
+    test("start generates an (unconfirmed) secret",
+         bool(tia.totp_secret_encrypted) and tia.totp_enabled is False)
+    test("setup page shows a QR code", b'data:image/png;base64,' in r.data)
+
+    r = c.post('/settings/2fa/enable', data={'code': '000000'})
+    db.session.refresh(tia)
+    test("wrong confirmation code does not enable", tia.totp_enabled is False)
+
+    r = c.post('/settings/2fa/enable', data={'code': code_for(tia)})
+    db.session.refresh(tia)
+    test("correct code enables 2FA", tia.totp_enabled is True)
+    test("backup codes shown once on enable", tia.totp_backup_codes
+         and twofa.backup_codes_remaining(tia.totp_backup_codes) == 10)
+
+    print("\n=== Login second-step gate ===")
+    c.post('/logout')
+    r = c.post('/login', data={'username': 'tia', 'password': 'password123'})
+    test("password step redirects to 2FA (not dashboard)",
+         r.status_code == 302 and '/login/2fa' in r.headers.get('Location', ''))
+    test("pending 2FA does NOT authenticate",
+         c.get('/').status_code == 302)  # dashboard still gated
+
+    r = c.post('/login/2fa', data={'code': '000000'})
+    test("wrong 2FA code keeps you out", c.get('/').status_code == 302)
+
+    r = c.post('/login/2fa', data={'code': code_for(tia)}, follow_redirects=False)
+    test("correct 2FA code completes login",
+         c.get('/').status_code == 200)
+
+    print("\n=== Backup-code login ===")
+    c.post('/logout')
+    c.post('/login', data={'username': 'tia', 'password': 'password123'})
+    # Grab a fresh backup code set by regenerating (we only have hashes stored)
+    c2 = app.test_client()  # fresh client to drive settings while first is mid-login
+    # Actually regenerate through the logged-out flow isn't possible; instead
+    # enable produced codes we didn't capture. Re-enroll to capture plaintext:
+    # (simplest correct path) complete this login first via TOTP:
+    c.post('/login/2fa', data={'code': code_for(tia)})
+    r = c.post('/settings/2fa/backup-codes', data={'code': code_for(tia)})
+    # Parse the shown plaintext codes out of the page
+    import re as _re
+    shown = _re.findall(rb'<li[^>]*>([0-9a-f]{4}-[0-9a-f]{4})</li>', r.data)
+    test("regenerate shows fresh plaintext codes", len(shown) == 10, f"got {len(shown)}")
+    backup = shown[0].decode()
+
+    c.post('/logout')
+    c.post('/login', data={'username': 'tia', 'password': 'password123'})
+    c.post('/login/2fa', data={'code': backup})
+    test("a backup code completes login", c.get('/').status_code == 200)
+    db.session.refresh(tia)
+    test("used backup code was consumed",
+         twofa.backup_codes_remaining(tia.totp_backup_codes) == 9)
+    # And it can't be reused
+    c.post('/logout')
+    c.post('/login', data={'username': 'tia', 'password': 'password123'})
+    c.post('/login/2fa', data={'code': backup})
+    test("consumed backup code can't be reused for login",
+         c.get('/').status_code == 302)
+    # Recover the session with a real code for the disable test
+    c.post('/login/2fa', data={'code': code_for(tia)})
+
+    print("\n=== Disable requires re-proving identity ===")
+    r = c.post('/settings/2fa/disable', data={'password': 'wrong-password'})
+    db.session.refresh(tia)
+    test("wrong password does not disable", tia.totp_enabled is True)
+    r = c.post('/settings/2fa/disable', data={'password': 'password123'})
+    db.session.refresh(tia)
+    test("correct password disables and clears the secret",
+         tia.totp_enabled is False and not tia.totp_secret_encrypted
+         and not tia.totp_backup_codes)
+
+    print("\n=== Non-2FA accounts unaffected ===")
+    c.post('/logout')
+    c.post('/signup', data={'username': 'notfa', 'email': 'no@corp.com',
+                            'password': 'password123', 'company_name': 'NoCo'})
+    c.post('/logout')
+    r = c.post('/login', data={'username': 'notfa', 'password': 'password123'})
+    test("account without 2FA logs straight in",
+         r.status_code == 302 and '/login/2fa' not in r.headers.get('Location', ''))
+
+print("\n" + "=" * 50)
+print(f"Results: {passed} passed, {failed} failed out of {passed + failed} tests")
+sys.exit(0 if failed == 0 else 1)

--- a/test_ocr.py
+++ b/test_ocr.py
@@ -1,0 +1,123 @@
+"""Tests for scanned-PDF OCR.
+
+Covers: availability probe, real end-to-end recognition (when Tesseract is
+installed), the sidecar cache, graceful degradation when OCR is unavailable,
+parse_document routing (ocr flag, image files), and the sparse-text threshold
+that decides when a PDF is treated as a scan.
+
+Standalone runner: python test_ocr.py
+"""
+import os
+import sys
+import tempfile
+from unittest.mock import patch
+
+from PIL import Image, ImageDraw, ImageFont
+
+import document_parser
+import ocr
+
+passed = failed = skipped = 0
+
+
+def test(name, cond, detail=""):
+    global passed, failed
+    if cond:
+        passed += 1; print(f"  PASS: {name}")
+    else:
+        failed += 1; print(f"  FAIL: {name} - {detail}")
+
+
+def skip(name, why):
+    global skipped
+    skipped += 1
+    print(f"  SKIP: {name} - {why}")
+
+
+def make_scanned_pdf(text, path):
+    """A PDF whose single page is an IMAGE of text — i.e. a scan with no
+    embedded text layer."""
+    img = Image.new("RGB", (1600, 500), "white")
+    draw = ImageDraw.Draw(img)
+    try:
+        font = ImageFont.truetype("/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf", 60)
+    except Exception:
+        font = ImageFont.load_default()
+    draw.text((60, 200), text, fill="black", font=font)
+    img.save(path, "PDF", resolution=200.0)
+
+
+tmp = tempfile.mkdtemp()
+
+print("\n=== Availability ===")
+test("available() returns a bool without raising", isinstance(ocr.available(), bool))
+print(f"  (OCR available in this environment: {ocr.available()})")
+
+print("\n=== Sparse-text detection routing ===")
+scan_pdf = os.path.join(tmp, "scan.pdf")
+make_scanned_pdf("OCRABLE SCOPE TOKEN 12345", scan_pdf)
+
+# Fast pass (no OCR) sees essentially nothing — it's an image.
+fast = document_parser.parse_document(scan_pdf)
+test("scanned PDF yields little/no text without OCR", len(fast.strip()) < 100,
+     f"got {len(fast.strip())} chars")
+
+print("\n=== Graceful degradation (OCR unavailable) ===")
+with patch.object(ocr, "available", return_value=False):
+    degraded = document_parser.parse_document(scan_pdf, ocr=True)
+    test("parse_document(ocr=True) never crashes when OCR is off",
+         isinstance(degraded, str))
+    test("image file returns '' when OCR is off",
+         ocr.image_text(scan_pdf) == "")
+
+print("\n=== Real end-to-end OCR ===")
+if ocr.available():
+    # Clear the sidecar cache for a clean run
+    sc = ocr.__dict__["_sidecar"](scan_pdf)
+    if sc.exists():
+        sc.unlink()
+
+    recovered = document_parser.parse_document(scan_pdf, ocr=True)
+    test("OCR recovers text from a scanned PDF",
+         "SCOPE" in recovered.upper() and "TOKEN" in recovered.upper(),
+         f"got: {recovered!r}")
+    test("OCR output is much richer than the fast pass",
+         len(recovered.strip()) > len(fast.strip()))
+
+    test("sidecar cache written", sc.exists())
+    # Second call must hit the cache, not re-render/re-OCR.
+    with patch("pypdfium2.PdfDocument", side_effect=AssertionError("should not re-render")):
+        cached = ocr.pdf_text(scan_pdf)
+        test("second OCR call served from cache (no re-render)",
+             "SCOPE" in cached.upper())
+
+    # Image-file OCR path
+    png = os.path.join(tmp, "note.png")
+    img = Image.new("RGB", (900, 240), "white")
+    d = ImageDraw.Draw(img)
+    try:
+        f = ImageFont.truetype("/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf", 56)
+    except Exception:
+        f = ImageFont.load_default()
+    d.text((40, 90), "IMAGE OCR WORKS", fill="black", font=f)
+    img.save(png)
+    img_text = document_parser.parse_document(png, ocr=True)
+    test("image files OCR through parse_document",
+         "IMAGE" in img_text.upper() and "OCR" in img_text.upper(),
+         f"got: {img_text!r}")
+else:
+    skip("real OCR recognition", "Tesseract binary not installed")
+    skip("sidecar cache", "Tesseract binary not installed")
+    skip("image OCR", "Tesseract binary not installed")
+
+print("\n=== Non-OCR formats unaffected ===")
+txt = os.path.join(tmp, "plain.txt")
+with open(txt, "w") as fh:
+    fh.write("plain text stays plain")
+test("txt files ignore the ocr flag",
+     document_parser.parse_document(txt, ocr=True) == "plain text stays plain")
+
+print("\n" + "=" * 50)
+print(f"Results: {passed} passed, {failed} failed, {skipped} skipped "
+      f"out of {passed + failed + skipped} checks")
+sys.exit(0 if failed == 0 else 1)

--- a/test_p0_fixes.py
+++ b/test_p0_fixes.py
@@ -1,0 +1,256 @@
+"""Regression tests for the five P0 audit fixes.
+
+P0-1  Org templates load with Auto-Detect (vertical resolved BEFORE template
+      queries, with a 'general' fallback tier).
+P0-2  Answered clarification questions are fed back into regeneration, re-asked
+      duplicates don't loop/duplicate rows, and question-only runs don't
+      consume the monthly generation quota.
+P0-3  Hosted (non-SELF_HOSTED) generations never inject the install-level
+      sample boilerplate / reference proposals into the prompt.
+P0-4  Proposal reads are DB-canonical (survive a missing/stale local file);
+      edit writes mirror to object storage.
+P0-5  The customer portal renders the version pinned at share time, not
+      whatever is latest; re-sharing re-pins.
+
+Standalone runner: python test_p0_fixes.py
+"""
+import io
+import os
+import sys
+from unittest.mock import patch
+
+os.environ['FLASK_SECRET_KEY'] = 'test-secret-key-12345'
+os.environ.pop('APP_ENV', None)
+os.environ.pop('SELF_HOSTED', None)
+
+import docx as _docx
+
+import app as appmod
+from app import app, db
+import billing
+import proposal_agent
+from models import (Organization, Project, Proposal, ProposalQuestion,
+                    ProposalShare, ProposalVersion, User)
+
+app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+app.config['TESTING'] = True
+
+passed = failed = 0
+
+
+def test(name, cond, detail=""):
+    global passed, failed
+    if cond:
+        passed += 1; print(f"  PASS: {name}")
+    else:
+        failed += 1; print(f"  FAIL: {name} - {detail}")
+
+
+def make_docx_bytes(text):
+    d = _docx.Document()
+    d.add_paragraph(text)
+    buf = io.BytesIO()
+    d.save(buf)
+    buf.seek(0)
+    return buf
+
+
+# Canned generation results -------------------------------------------------
+
+QUESTION = {"question": "What margin target should be used?", "context": "",
+            "resolution_path": "internal", "category": "pricing", "ai_suggestion": ""}
+
+def result_with_questions(**kw):
+    return {
+        "proposal_markdown": "# Proposal V1MARKER\n\nConfidence Score: 80%",
+        "action_items": [], "confidence_score": 80, "document_type": "RFP",
+        "vertical": kw.get("vertical", "data_center"),
+        "vertical_label": "Data Center / Mission Critical",
+        "generated_at": "2026-01-01T00:00:00+00:00",
+        "questions": [dict(QUESTION)],
+    }
+
+def result_full(**kw):
+    r = result_with_questions(**kw)
+    return r  # same shape; caller decides whether questions halt
+
+
+captured_calls = []
+
+def fake_generate(rfp_text, **kwargs):
+    captured_calls.append(kwargs)
+    # First call: halt with a question. Second call: re-ask the SAME question
+    # (worst case) alongside a full proposal — dedupe must fall through.
+    return result_with_questions(vertical=kwargs.get("vertical"))
+
+
+with app.app_context():
+    db.drop_all(); db.create_all()
+    c = app.test_client()
+
+    # --- Workspace with a 'general' template, generating with Auto-Detect ---
+    c.post('/signup', data={'username': 'pat', 'email': 'pat@a.com',
+                            'password': 'password123', 'display_name': 'Pat',
+                            'company_name': 'OrgA'})
+    pat = User.query.filter_by(username='pat').first()
+
+    r = c.post('/settings/upload-template', data={
+        'template_name': 'House Style', 'vertical': 'general', 'template_type': 'proposal',
+        'template_file': (make_docx_bytes('TEMPLATEMARKER structure'), 'house.docx'),
+    }, content_type='multipart/form-data')
+    test("template upload accepted", r.status_code == 302)
+
+    r = c.post('/projects/new', data={'project_name': 'DC Bid', 'client_name': 'Acme'})
+    project = Project.query.filter_by(name='DC Bid').first()
+    test("project created", project is not None)
+
+    rfp_text = ("Request for proposal: data center EPMS for a new data hall. "
+                "Meter all switchgear and PDU equipment; integrate the EPMS "
+                "with the colocation data center BMS.")
+    c.post(f'/projects/{project.id}/upload', data={
+        'file_type': 'rfp',
+        'documents': (io.BytesIO(rfp_text.encode()), 'rfp.txt'),
+    }, content_type='multipart/form-data')
+
+    print("\n=== P0-1 + P0-2 + P0-3 (call-site): generation flow ===")
+    with patch('app.generate_proposal', side_effect=fake_generate):
+        r = c.post(f'/projects/{project.id}/generate',
+                   data={'vertical': 'auto', 'output_format': 'docx'})
+        test("generate enqueued", r.status_code == 302)
+
+    kw = captured_calls[-1]
+    test("P0-1: vertical resolved before call (not 'auto')",
+         kw.get("vertical") == "data_center", f"got {kw.get('vertical')}")
+    tmpls = kw.get("user_templates") or {}
+    test("P0-1: org 'general' template loaded for detected vertical",
+         "TEMPLATEMARKER" in (tmpls.get("proposal") or ""), f"got {list(tmpls)}")
+    test("P0-3: hosted mode passes include_global_boilerplate=False",
+         kw.get("include_global_boilerplate") is False)
+    test("P0-2: first run passes no answered questions",
+         not kw.get("answered_questions"))
+
+    q_count = ProposalQuestion.query.filter_by(project_id=project.id).count()
+    test("question recorded once", q_count == 1, f"got {q_count}")
+    test("question-only run produced no proposal",
+         Proposal.query.filter_by(project_id=project.id).count() == 0)
+    test("P0-2: question-only run consumed NO generation quota",
+         billing.generations_this_month(pat.org_id) == 0,
+         f"got {billing.generations_this_month(pat.org_id)}")
+
+    # Answer the question, regenerate; the AI re-asks the same question.
+    q = ProposalQuestion.query.filter_by(project_id=project.id).first()
+    c.post(f'/projects/{project.id}/questions', data={f'answer_{q.id}': '12% margin'})
+    db.session.refresh(q)
+    test("answer stored", q.status == 'answered' and q.answer == '12% margin')
+
+    with patch('app.generate_proposal', side_effect=fake_generate):
+        c.post(f'/projects/{project.id}/generate',
+               data={'vertical': 'auto', 'output_format': 'docx'})
+
+    kw2 = captured_calls[-1]
+    aq = kw2.get("answered_questions") or []
+    test("P0-2: regeneration receives the answer",
+         any(a.get("answer") == "12% margin" for a in aq), f"got {aq}")
+    test("P0-2: re-asked duplicate not re-recorded",
+         ProposalQuestion.query.filter_by(project_id=project.id).count() == 1)
+    proposal = Proposal.query.filter_by(project_id=project.id).first()
+    test("P0-2: duplicate-only questions fall through to a saved proposal",
+         proposal is not None)
+    test("P0-2: produced proposal now counts as 1 generation",
+         billing.generations_this_month(pat.org_id) == 1,
+         f"got {billing.generations_this_month(pat.org_id)}")
+
+    print("\n=== P0-4: DB-canonical reads + synced writes ===")
+    from config.settings import GENERATED_DIR
+    md_path = GENERATED_DIR / proposal.md_file
+    if md_path.exists():
+        md_path.unlink()  # simulate redeploy / other instance: local file gone
+    r = c.get(f'/proposal/{proposal.id}')
+    test("view works with md file missing (DB version fallback)",
+         r.status_code == 200 and b'V1MARKER' in r.data)
+    r = c.get(f'/proposal/{proposal.id}/edit')
+    test("editor loads content with md file missing",
+         r.status_code == 200 and b'V1MARKER' in r.data)
+
+    with patch.object(appmod.storage, 'sync_up') as sync_mock:
+        c.post(f'/proposal/{proposal.id}/edit', data={
+            'markdown_content': '# Proposal V2MARKER\n\nrevised',
+            'change_summary': 'v2',
+        })
+        test("edit mirrors md+docx to object storage", sync_mock.call_count >= 2,
+             f"sync_up called {sync_mock.call_count}x")
+    test("edit created v2",
+         ProposalVersion.query.filter_by(proposal_id=proposal.id).count() == 2)
+
+    # Legacy fallback: version-less proposal still reads from the file
+    legacy = Proposal(project_id=project.id, job_id='legacy1', md_file='legacy1.md')
+    db.session.add(legacy); db.session.commit()
+    (GENERATED_DIR / 'legacy1.md').write_text('# LEGACYMARKER', encoding='utf-8')
+    test("legacy file-only proposal still renders",
+         b'LEGACYMARKER' in c.get(f'/proposal/{legacy.id}').data)
+    (GENERATED_DIR / 'legacy1.md').unlink()
+
+    print("\n=== P0-5: portal pinned to shared version ===")
+    # Re-pin share flow: share was never created yet; create pins current (v2)
+    c.post(f'/proposal/{proposal.id}/share', data={})
+    share = ProposalShare.query.filter_by(proposal_id=proposal.id).first()
+    test("share pinned to current version", share is not None and share.version_number == 2,
+         f"got {share.version_number if share else None}")
+
+    # Internal edit AFTER sharing — customer must keep seeing v2
+    c.post(f'/proposal/{proposal.id}/edit', data={
+        'markdown_content': '# Proposal V3MARKER\n\ninternal work-in-progress',
+        'change_summary': 'v3',
+    })
+    body = c.get(f'/p/{share.token}').data
+    test("portal shows the pinned v2, not the newer v3",
+         b'V2MARKER' in body and b'V3MARKER' not in body)
+
+    # Owner explicitly updates the customer view -> re-pins to latest
+    c.post(f'/proposal/{proposal.id}/share', data={})
+    db.session.refresh(share)
+    body = c.get(f'/p/{share.token}').data
+    test("re-share re-pins to v3", share.version_number == 3 and b'V3MARKER' in body)
+
+    # Legacy shares (version_number 0) fall back to latest
+    share.version_number = 0; db.session.commit()
+    test("legacy unpinned share falls back to latest",
+         b'V3MARKER' in c.get(f'/p/{share.token}').data)
+
+print("\n=== P0-3: prompt assembly (real generate_proposal, fake client) ===")
+
+class _FakeStream:
+    def __enter__(self): return self
+    def __exit__(self, *a): return False
+    @property
+    def text_stream(self):
+        yield "# Proposal\n\nConfidence Score: 90%"
+
+class _FakeClient:
+    def __init__(self, sink): self._sink = sink
+    @property
+    def messages(self): return self
+    def stream(self, **kwargs):
+        self._sink.append(kwargs)
+        return _FakeStream()
+
+for flag, name in ((False, "hosted"), (True, "self-hosted")):
+    sink = []
+    with patch.object(proposal_agent, '_make_client', lambda key, s=sink: _FakeClient(s)):
+        proposal_agent.generate_proposal(
+            "data center EPMS test document", vertical="data_center",
+            user_api_key="test-key", include_global_boilerplate=flag,
+        )
+    system = sink[0]["system"]
+    leaked = [m for m in ("E Tech Group", "Apex Technology", "[Your Company Name]")
+              if m in system]
+    if flag:
+        test(f"{name}: sample boilerplate still available", len(leaked) > 0,
+             "expected sample content in self-hosted prompt")
+    else:
+        test(f"{name}: no sample-company content in prompt", not leaked,
+             f"leaked: {leaked}")
+
+print("\n" + "=" * 50)
+print(f"Results: {passed} passed, {failed} failed out of {passed + failed} tests")
+sys.exit(0 if failed == 0 else 1)

--- a/test_p0_fixes.py
+++ b/test_p0_fixes.py
@@ -93,6 +93,9 @@ with app.app_context():
                             'password': 'password123', 'display_name': 'Pat',
                             'company_name': 'OrgA'})
     pat = User.query.filter_by(username='pat').first()
+    # Platform-key AI requires a verified email (P1 abuse gate)
+    pat.email_verified = True
+    db.session.commit()
 
     r = c.post('/settings/upload-template', data={
         'template_name': 'House Style', 'vertical': 'general', 'template_type': 'proposal',

--- a/test_p1_fixes.py
+++ b/test_p1_fixes.py
@@ -1,0 +1,379 @@
+"""Regression tests for the P1 audit batch.
+
+Auth: email uniqueness, email-change re-verification, hashed tokens, password
+change, member deactivation, platform-admin lockout, platform-AI gate.
+Org identity: workspace-level logo/branding, setup-wizard org awareness.
+AI pipeline: metered+rate-limited chat, jobified scope/estimate, xlsx parsing,
+legal docs + project rate sheets in generation context.
+Lifecycle/UX: redline tags survive sanitizing, parse receipts, scope item
+editing, human-preserving scope re-draft, document & project deletion,
+share expiry.
+
+Standalone runner: python test_p1_fixes.py
+"""
+import io
+import os
+import sys
+from unittest.mock import patch
+
+os.environ['FLASK_SECRET_KEY'] = 'test-secret-key-12345'
+os.environ.pop('APP_ENV', None)
+
+import openpyxl
+
+import app as appmod
+from app import app, db
+import billing
+import crypto_util
+import htmlsafe
+import proposal_agent
+from document_parser import parse_document
+from models import (BackgroundJob, EstimateLineItem, Organization, Project,
+                    ProjectDocument, ProjectScope, Proposal, ProposalEstimate,
+                    ProposalShare, ProposalVersion, ScopeItem, User, UserRateSheet,
+                    UserToken)
+
+app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+app.config['TESTING'] = True
+
+passed = failed = 0
+
+
+def test(name, cond, detail=""):
+    global passed, failed
+    if cond:
+        passed += 1; print(f"  PASS: {name}")
+    else:
+        failed += 1; print(f"  FAIL: {name} - {detail}")
+
+
+def login(c, username, password='password123'):
+    c.post('/logout')
+    c.post('/login', data={'username': username, 'password': password})
+
+
+with app.app_context():
+    db.drop_all(); db.create_all()
+    c = app.test_client()
+
+    c.post('/signup', data={'username': 'ana', 'email': 'ana@corp.com',
+                            'password': 'password123', 'display_name': 'Ana',
+                            'company_name': 'AnaCorp'})
+    ana = User.query.filter_by(username='ana').first()
+    ana.email_verified = True
+    db.session.commit()
+    org = db.session.get(Organization, ana.org_id)
+
+    print("\n=== Email uniqueness & verification ===")
+    c.post('/logout')
+    r = c.post('/signup', data={'username': 'imposter', 'email': 'ANA@corp.com',
+                                'password': 'password123'})
+    test("duplicate email (case-insensitive) rejected",
+         User.query.filter_by(username='imposter').first() is None)
+
+    login(c, 'ana')
+    c.post('/settings', data={'display_name': 'Ana', 'email': 'ana-new@corp.com',
+                              'font_preference': 'Calibri', 'llm_model': ana.llm_model})
+    db.session.refresh(ana)
+    test("email change stored", ana.email == 'ana-new@corp.com')
+    test("email change resets verification", ana.email_verified is False)
+    ana.email_verified = True; db.session.commit()
+
+    # Collision on change
+    other = User(username='zed', email='zed@corp.com', org_id=ana.org_id)
+    other.set_password('password123'); db.session.add(other); db.session.commit()
+    c.post('/settings', data={'display_name': 'Ana', 'email': 'zed@corp.com',
+                              'font_preference': 'Calibri', 'llm_model': ana.llm_model})
+    db.session.refresh(ana)
+    test("email change to an existing address rejected", ana.email == 'ana-new@corp.com')
+
+    print("\n=== Hashed tokens & password change ===")
+    raw = appmod._issue_token(ana, 'reset', hours=2)
+    row = UserToken.query.filter_by(user_id=ana.id, purpose='reset').first()
+    test("reset token stored hashed", row is not None and row.token != raw
+         and row.token == appmod._hash_token(raw))
+    r = c.post(f'/reset-password/{raw}', data={'password': 'newpassword9',
+                                               'confirm_password': 'newpassword9'})
+    login(c, 'ana', 'newpassword9')
+    test("reset with raw token works end-to-end",
+         c.get('/').status_code == 200)
+
+    c.post('/settings/change-password', data={'current_password': 'wrong',
+                                              'new_password': 'password123',
+                                              'confirm_password': 'password123'})
+    db.session.refresh(ana)
+    test("password change requires current password", not ana.check_password('password123')
+         or ana.check_password('newpassword9') is False)
+    c.post('/settings/change-password', data={'current_password': 'newpassword9',
+                                              'new_password': 'password123',
+                                              'confirm_password': 'password123'})
+    db.session.refresh(ana)
+    test("password change works", ana.check_password('password123'))
+
+    print("\n=== Member deactivation ===")
+    from flask import g
+
+    def _fresh_request_state():
+        # These suites run inside ONE long-lived app context, so flask-login's
+        # per-context user cache (g._login_user) survives across simulated
+        # requests. Production pushes a fresh context per request; clearing the
+        # cache reproduces that so the user_loader actually runs.
+        if hasattr(g, '_login_user'):
+            delattr(g, '_login_user')
+
+    org.plan = 'business'  # seat headroom so reactivation isn't limit-blocked
+    bob = User(username='bob', email='bob@corp.com', org_id=ana.org_id, role='proposal')
+    bob.set_password('password123'); db.session.add(bob); db.session.commit()
+    seats_before = billing.seats_used(ana.org_id)
+
+    c2 = app.test_client()
+    login(c2, 'bob')
+    test("bob signed in", c2.get('/').status_code == 200)
+
+    login(c, 'ana')
+    c.post(f'/admin/deactivate-user/{bob.id}')
+    db.session.refresh(bob)
+    test("bob deactivated", bob.is_active is False)
+    test("deactivation frees the seat", billing.seats_used(ana.org_id) == seats_before - 1)
+    _fresh_request_state()
+    test("existing session invalidated", c2.get('/').status_code == 302)
+    _fresh_request_state()
+    c2.post('/login', data={'username': 'bob', 'password': 'password123'})
+    _fresh_request_state()
+    test("deactivated login blocked", c2.get('/').status_code == 302)
+
+    # Reactivation at the seat limit must be refused; with headroom it works.
+    # (Re-login: the interleaved c2 requests poisoned the shared-context user
+    # cache — same reason _fresh_request_state exists.)
+    login(c, 'ana')
+    org.plan = 'free'; db.session.commit()  # ana + zed already fill 2 free seats
+    c.post(f'/admin/reactivate-user/{bob.id}')
+    db.session.refresh(bob)
+    test("reactivation blocked at seat limit", bob.is_active is False)
+    org.plan = 'business'; db.session.commit()
+    c.post(f'/admin/reactivate-user/{bob.id}')
+    db.session.refresh(bob)
+    test("reactivation works with seat headroom", bob.is_active is True)
+
+    print("\n=== Signup throttle & platform-admin lockout ===")
+    for _ in range(5):
+        appmod._record_signup('9.9.9.9')
+    test("signup rate limit trips after 5/hr per IP", appmod._signup_rate_limited('9.9.9.9'))
+
+    pa = app.test_client()
+    blocked = False
+    for i in range(9):
+        r = pa.post('/platform-admin/login',
+                    data={'email': 'owner@x.com', 'password': 'nope'})
+        if b'Too many attempts' in r.data:
+            blocked = True
+            break
+    test("platform-admin login rate limited", blocked, "never throttled")
+
+    print("\n=== Platform-AI gate (verified email or own key) ===")
+    login(c, 'ana')  # restore c's cached identity after pa-client requests
+    ana.email_verified = False; db.session.commit()
+    proj = Project(user_id=ana.id, org_id=ana.org_id, name='GateBid')
+    db.session.add(proj); db.session.flush()
+    db.session.add(ProjectDocument(project_id=proj.id, filename='r.txt',
+                                   original_filename='r.txt', file_type='rfp',
+                                   file_path='/tmp/none.txt', file_size=1))
+    db.session.commit()
+    c.post(f'/projects/{proj.id}/generate', data={'vertical': 'auto'})
+    test("unverified user without key blocked from generation",
+         BackgroundJob.query.filter_by(kind='generate_proposal').count() == 0)
+
+    # With their OWN key, unverified users may generate (they spend their own money)
+    ana.api_key_encrypted = crypto_util.encrypt('sk-own-key'); db.session.commit()
+    def fake_gate_gen(rfp_text, **kwargs):
+        return {"proposal_markdown": "# G\n\nConfidence Score: 70%", "action_items": [],
+                "confidence_score": 70, "document_type": "RFP", "vertical": "general",
+                "vertical_label": "General", "generated_at": "2026-01-01T00:00:00+00:00"}
+    with patch('app.generate_proposal', side_effect=fake_gate_gen):
+        c.post(f'/projects/{proj.id}/generate', data={'vertical': 'general'})
+    test("own-key user passes the gate while unverified",
+         BackgroundJob.query.filter_by(kind='generate_proposal').count() == 1)
+    ana.email_verified = True
+    ana.api_key_encrypted = ""
+    db.session.commit()
+
+    print("\n=== Org-level branding ===")
+    import PIL.Image
+    buf = io.BytesIO()
+    PIL.Image.new('RGB', (80, 40), (10, 100, 100)).save(buf, format='PNG')
+    buf.seek(0)
+    login(c, 'ana')
+    c.post('/settings/upload-logo', data={'company_logo': (buf, 'brand.png')},
+           content_type='multipart/form-data')
+    db.session.refresh(org)
+    test("logo stored on the ORG", bool(org.logo_path))
+    kw = appmod._logo_docx_kwargs(org, font_user=ana)
+    test("brand kwargs come from org", kw.get('logo_path') == org.logo_path
+         and kw.get('company_name') == org.name, f"got {kw}")
+    prog = appmod._setup_progress(bob)
+    logo_step = next(s for s in prog['steps'] if s['key'] == 'logo')
+    company_step = next(s for s in prog['steps'] if s['key'] == 'company')
+    test("teammate's setup wizard sees org logo/company done",
+         logo_step['done'] and company_step['done'])
+
+    print("\n=== Metered + rate-limited chat ===")
+    ana.api_key_encrypted = crypto_util.encrypt('sk-chat-key')
+    db.session.commit()
+    class _Block:
+        type = "text"; text = "CANNED_HELP"
+    class _Resp:
+        content = [_Block()]
+    class _FakeMessages:
+        def __init__(self, sink): self._sink = sink
+        def create(self, **kw):
+            self._sink.append(kw); return _Resp()
+    class _FakeClient:
+        def __init__(self, sink): self.messages = _FakeMessages(sink)
+    sink = []
+    with patch.object(proposal_agent, '_make_client', lambda key, s=sink: _FakeClient(s)):
+        r = c.post('/api/chat', json={'message': 'how do I generate?'})
+        test("chat routed through metered client factory",
+             sink and r.get_json().get('reply') == 'CANNED_HELP', f"got {r.get_json()}")
+        throttled = False
+        for _ in range(25):
+            r = c.post('/api/chat', json={'message': 'again'})
+            if 'catch up' in (r.get_json().get('reply') or ''):
+                throttled = True
+                break
+        test("chat rate limit engages", throttled)
+    appmod._AI_CALLS.clear()
+
+    print("\n=== Parsing & context fixes ===")
+    wb = openpyxl.Workbook(); ws = wb.active
+    ws.append(['Item', 'Price']); ws.append(['XLSMARKER Widget', 42])
+    xbuf = io.BytesIO(); wb.save(xbuf); xbuf.seek(0)
+    xpath = '/tmp/claude-p1-test.xlsx'
+    with open(xpath, 'wb') as fh:
+        fh.write(xbuf.read())
+    test("parse_document reads xlsx", 'XLSMARKER' in parse_document(xpath))
+    os.unlink(xpath)
+
+    test("sanitizer keeps redline ins/del",
+         '<ins>' in htmlsafe.sanitize('<p><ins>new</ins> <del>old</del></p>')
+         and '<del>' in htmlsafe.sanitize('<p><del>old</del></p>'))
+
+    # Upload a real project with rfp + legal + rate-sheet docs; capture what
+    # reaches the AI.
+    c.post('/projects/new', data={'project_name': 'CtxBid', 'client_name': 'Acme'})
+    ctx = Project.query.filter_by(name='CtxBid').first()
+    c.post(f'/projects/{ctx.id}/upload', data={
+        'file_type': 'rfp',
+        'documents': (io.BytesIO(b'RFPMARKER data center EPMS switchgear PDU data hall'), 'rfp.txt'),
+    }, content_type='multipart/form-data')
+    c.post(f'/projects/{ctx.id}/upload', data={
+        'file_type': 'legal',
+        'documents': (io.BytesIO(b'LEGALMARKER liquidated damages clause'), 'msa.txt'),
+    }, content_type='multipart/form-data')
+    xbuf2 = io.BytesIO(); wb.save(xbuf2); xbuf2.seek(0)
+    c.post(f'/projects/{ctx.id}/upload', data={
+        'file_type': 'rate_sheet',
+        'documents': (xbuf2, 'projectrates.xlsx'),
+    }, content_type='multipart/form-data')
+
+    rfp_doc = ProjectDocument.query.filter_by(project_id=ctx.id, file_type='rfp').first()
+    test("parse receipt recorded at upload", (rfp_doc.text_chars or 0) > 10,
+         f"got {rfp_doc.text_chars}")
+
+    gen_capture = {}
+    def fake_generate(rfp_text, **kwargs):
+        gen_capture['rfp_text'] = rfp_text
+        gen_capture['kwargs'] = kwargs
+        return {"proposal_markdown": "# P\n\nConfidence Score: 80%", "action_items": [],
+                "confidence_score": 80, "document_type": "RFP",
+                "vertical": kwargs.get('vertical'), "vertical_label": "General",
+                "generated_at": "2026-01-01T00:00:00+00:00"}
+    with patch('app.generate_proposal', side_effect=fake_generate):
+        c.post(f'/projects/{ctx.id}/generate', data={'vertical': 'general'})
+    test("legal docs included in AI context", 'LEGALMARKER' in gen_capture.get('rfp_text', ''))
+    rs = gen_capture.get('kwargs', {}).get('rate_sheet_data') or {}
+    rs_text = " ".join(v.get('raw_text', '') for v in rs.values())
+    test("project rate-sheet doc reaches pricing context", 'XLSMARKER' in rs_text,
+         f"keys={list(rs)}")
+
+    print("\n=== Jobified scope with human-preserving re-draft + item edit ===")
+    def fake_scope(text, **kwargs):
+        return {"vertical": "general", "vertical_label": "General",
+                "summary": "sum", "items": [
+                    {"item": "AI item one", "category": "general"},
+                    {"item": "AI item two", "category": "general"}]}
+    with patch('app.draft_scope_of_work', side_effect=fake_scope):
+        r = c.post(f'/projects/{ctx.id}/scope/generate', data={'vertical': 'auto'})
+    test("scope drafting runs as a job", r.status_code == 302 and '/jobs/' in r.headers.get('Location', ''))
+    scope = ProjectScope.query.filter_by(project_id=ctx.id).first()
+    test("scope created by job", scope is not None and
+         ScopeItem.query.filter_by(scope_id=scope.id).count() == 2)
+
+    c.post(f'/projects/{ctx.id}/scope/add', data={'item_text': 'HUMANITEM as-builts',
+                                                  'category': 'documentation'})
+    with patch('app.draft_scope_of_work', side_effect=fake_scope):
+        c.post(f'/projects/{ctx.id}/scope/generate', data={'vertical': 'auto'})
+    scope = ProjectScope.query.filter_by(project_id=ctx.id).first()
+    kept = ScopeItem.query.filter_by(scope_id=scope.id, source='human').all()
+    test("re-draft keeps team-added items",
+         len(kept) == 1 and 'HUMANITEM' in kept[0].item_text)
+
+    item = ScopeItem.query.filter_by(scope_id=scope.id, source='ai').first()
+    c.post(f'/projects/{ctx.id}/scope/items/{item.id}/edit',
+           data={'item_text': 'EDITED wording of item'})
+    db.session.refresh(item)
+    test("scope item wording editable", item.item_text.startswith('EDITED'))
+
+    c.post(f'/projects/{ctx.id}/scope/approve')
+    c.post(f'/projects/{ctx.id}/scope/items/{item.id}/edit',
+           data={'item_text': 'EDITED again'})
+    db.session.refresh(scope)
+    test("editing an approved scope re-opens it", scope.status == 'draft')
+
+    print("\n=== Jobified estimate draft ===")
+    prop = Proposal.query.filter_by(project_id=ctx.id).first()
+    def fake_estimate(rfp_text, **kwargs):
+        return {"currency": "USD", "items": [
+            {"kind": "labor", "description": "Eng hours", "quantity": 10,
+             "unit": "hrs", "unit_cost": 150}]}
+    with patch('app.draft_estimate', side_effect=fake_estimate):
+        r = c.post(f'/proposal/{prop.id}/estimate/draft')
+    est = ProposalEstimate.query.filter_by(proposal_id=prop.id).first()
+    test("estimate drafting runs as a job and saves rows",
+         r.status_code == 302 and '/jobs/' in r.headers.get('Location', '')
+         and est is not None and est.items.count() == 1)
+
+    print("\n=== Deletion lifecycle & share expiry ===")
+    doc = ProjectDocument.query.filter_by(project_id=ctx.id, file_type='legal').first()
+    doc_path = doc.file_path
+    c.post(f'/documents/{doc.id}/delete')
+    test("document deletable (row + file)",
+         db.session.get(ProjectDocument, doc.id) is None and not os.path.exists(doc_path))
+
+    c.post(f'/proposal/{prop.id}/share', data={})
+    share = ProposalShare.query.filter_by(proposal_id=prop.id).first()
+    test("share link gets an expiry", share is not None and share.expires_at is not None)
+
+    ctx_id, prop_id = ctx.id, prop.id
+    c.post(f'/projects/{ctx_id}/delete', data={'confirm_name': 'WRONG'})
+    test("project delete requires exact name", db.session.get(Project, ctx_id) is not None)
+    c.post(f'/projects/{ctx_id}/delete', data={'confirm_name': 'CtxBid'})
+    test("project delete cascades",
+         db.session.get(Project, ctx_id) is None
+         and Proposal.query.filter_by(project_id=ctx_id).count() == 0
+         and ProposalVersion.query.filter_by(proposal_id=prop_id).count() == 0
+         and ProposalShare.query.filter_by(proposal_id=prop_id).count() == 0
+         and ProjectDocument.query.filter_by(project_id=ctx_id).count() == 0)
+
+    print("\n=== Travel rate-sheet upload label ===")
+    xbuf3 = io.BytesIO(); wb.save(xbuf3); xbuf3.seek(0)
+    c.post('/settings/add-travel-rate', data={
+        'travel_rate_file': (xbuf3, 'travel.xlsx'),
+    }, content_type='multipart/form-data')
+    tsheet = UserRateSheet.query.filter_by(org_id=ana.org_id).order_by(
+        UserRateSheet.uploaded_at.desc()).first()
+    test("travel sheet labeled travel_rates", tsheet is not None
+         and tsheet.sheet_type == 'travel_rates', f"got {tsheet.sheet_type if tsheet else None}")
+
+print("\n" + "=" * 50)
+print(f"Results: {passed} passed, {failed} failed out of {passed + failed} tests")
+sys.exit(0 if failed == 0 else 1)

--- a/test_p1_fixes.py
+++ b/test_p1_fixes.py
@@ -146,7 +146,9 @@ with app.app_context():
     # (Re-login: the interleaved c2 requests poisoned the shared-context user
     # cache — same reason _fresh_request_state exists.)
     login(c, 'ana')
-    org.plan = 'free'; db.session.commit()  # ana + zed already fill 2 free seats
+    # ana + zed already fill 2 free seats; end the signup trial so FREE limits
+    # (not trial-Pro limits) apply to the seat check.
+    org.plan = 'free'; org.trial_ends_at = None; db.session.commit()
     c.post(f'/admin/reactivate-user/{bob.id}')
     db.session.refresh(bob)
     test("reactivation blocked at seat limit", bob.is_active is False)

--- a/test_p2_fixes.py
+++ b/test_p2_fixes.py
@@ -1,0 +1,204 @@
+"""Regression tests for the P2 batch: N+1 elimination + pagination, trial
+enforcement, local-timezone rendering, editor autosave/conflict guard, and the
+accessibility pass.
+
+Standalone runner: python test_p2_fixes.py
+"""
+import os
+import sys
+from datetime import datetime, timedelta, timezone
+
+os.environ['FLASK_SECRET_KEY'] = 'test-secret-key-12345'
+os.environ.pop('APP_ENV', None)
+
+from sqlalchemy import event
+
+import app as appmod
+from app import app, db
+import billing
+from models import (Organization, Project, ProjectDocument, Proposal,
+                    ProposalVersion, User)
+
+app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+app.config['TESTING'] = True
+
+passed = failed = 0
+
+
+def test(name, cond, detail=""):
+    global passed, failed
+    if cond:
+        passed += 1; print(f"  PASS: {name}")
+    else:
+        failed += 1; print(f"  FAIL: {name} - {detail}")
+
+
+class QueryCounter:
+    """Counts SELECT statements issued while attached to the engine."""
+    def __init__(self):
+        self.n = 0
+
+    def __call__(self, conn, cursor, statement, parameters, context, executemany):
+        if statement.lstrip().lower().startswith("select"):
+            self.n += 1
+
+
+with app.app_context():
+    db.drop_all(); db.create_all()
+    c = app.test_client()
+    c.post('/signup', data={'username': 'pia', 'email': 'pia@corp.com',
+                            'password': 'password123', 'display_name': 'Pia',
+                            'company_name': 'PiaCorp'})
+    pia = User.query.filter_by(username='pia').first()
+    pia.email_verified = True
+    org = db.session.get(Organization, pia.org_id)
+    db.session.commit()
+
+    print("\n=== Trial enforcement ===")
+    test("signup stamps a trial window", org.trial_ends_at is not None)
+    test("trial is active for a fresh workspace", billing.trial_active(org))
+    test("trial grants PRO limits on the free plan",
+         billing.limits_for(org)["generations_per_month"]
+         == billing.PLANS["pro"]["limits"]["generations_per_month"])
+    test("trial_days_left positive", billing.trial_days_left(org) > 0)
+
+    r = c.get('/billing')
+    test("billing page announces the trial", b'Pro trial active' in r.data)
+    r = c.get('/')
+    test("sidebar shows the trial chip", b'Pro trial' in r.data)
+
+    org.trial_ends_at = datetime.now(timezone.utc) - timedelta(days=1)
+    db.session.commit()
+    test("expired trial falls back to FREE limits",
+         billing.limits_for(org)["generations_per_month"]
+         == billing.PLANS["free"]["limits"]["generations_per_month"])
+    test("expired trial not active", not billing.trial_active(org))
+    r = c.get('/billing')
+    test("billing page announces trial ended", b'trial has ended' in r.data)
+
+    org.trial_ends_at = datetime.now(timezone.utc) + timedelta(days=5)
+    org.billing_status = 'past_due'
+    db.session.commit()
+    test("delinquency overrides trial (free limits)",
+         billing.limits_for(org)["generations_per_month"]
+         == billing.PLANS["free"]["limits"]["generations_per_month"])
+    org.billing_status = ''
+    org.plan = 'business'
+    db.session.commit()
+    test("paid plan ignores trial (business limits)",
+         billing.limits_for(org)["generations_per_month"] == -1)
+
+    print("\n=== N+1 elimination + pagination ===")
+    # 60 projects, each with a document; half with a proposal + version
+    for i in range(60):
+        p = Project(user_id=pia.id, org_id=pia.org_id, name=f'Bid {i:03d}',
+                    client_name='Acme', status='active')
+        db.session.add(p); db.session.flush()
+        db.session.add(ProjectDocument(
+            project_id=p.id, filename=f'd{i}', original_filename=f'd{i}.txt',
+            file_type='rfp', file_path=f'/tmp/none{i}.txt', file_size=10,
+            text_chars=100))
+        if i % 2 == 0:
+            prop = Proposal(project_id=p.id, job_id=f'job{i:03d}',
+                            md_file=f'p{i}.md', review_status='draft')
+            db.session.add(prop); db.session.flush()
+            db.session.add(ProposalVersion(
+                proposal_id=prop.id, version_number=1,
+                markdown_content=f'# Bid {i:03d}\n\nNEEDLE{i:03d} content'))
+    db.session.commit()
+
+    counter = QueryCounter()
+    event.listen(db.engine, "before_cursor_execute", counter)
+    r = c.get('/proposals')
+    event.remove(db.engine, "before_cursor_execute", counter)
+    test("proposals page renders with 60 projects", r.status_code == 200)
+    test("proposals page query count is bounded (no N+1)",
+         counter.n <= 40, f"issued {counter.n} SELECTs for 60 projects")
+    row_marker = b'class="clickable-row"'
+    n_rows = r.data.count(row_marker)
+    test("table paginated to 50 rows", n_rows == 50, f"got {n_rows}")
+    test("pagination nav present", b'Page 1 of 2' in r.data)
+    r2 = c.get('/proposals?page=2')
+    n_rows2 = r2.data.count(row_marker)
+    test("page 2 shows the remainder", n_rows2 == 10, f"got {n_rows2}")
+
+    counter = QueryCounter()
+    event.listen(db.engine, "before_cursor_execute", counter)
+    r = c.get('/')
+    event.remove(db.engine, "before_cursor_execute", counter)
+    test("dashboard renders with 60 active projects", r.status_code == 200)
+    test("dashboard query count is bounded (no N+1)",
+         counter.n <= 40, f"issued {counter.n} SELECTs for 60 projects")
+
+    r = c.get('/admin')
+    test("admin panel renders (bulk stats)",
+         r.status_code == 200 and b'Rep Performance' in r.data)
+
+    r = c.get('/documents')
+    test("document library renders paginated", r.status_code == 200
+         and b'Page 1 of 2' in r.data)
+
+    print("\n=== SQL-side proposal search ===")
+    counter = QueryCounter()
+    event.listen(db.engine, "before_cursor_execute", counter)
+    r = c.get('/search?q=NEEDLE042')
+    event.remove(db.engine, "before_cursor_execute", counter)
+    test("content search finds the proposal", b'Bid 042' in r.data)
+    test("search query count bounded", counter.n <= 30,
+         f"issued {counter.n} SELECTs")
+
+    print("\n=== Local timezone rendering ===")
+    out = str(appmod.localtime_filter(datetime(2026, 1, 5, 14, 30)))
+    test("localtime emits a <time> element with UTC ISO",
+         '<time' in out and 'data-utc="2026-01-05T14:30:00Z"' in out, out)
+    out_date = str(appmod.localtime_filter(datetime(2026, 1, 5, 14, 30), 'date'))
+    test("date style falls back to date-only", 'Jan 05, 2026' in out_date, out_date)
+    test("empty datetime renders empty", str(appmod.localtime_filter(None)) == "")
+    prop = Proposal.query.filter_by(job_id='job000').first()
+    proj = db.session.get(Project, prop.project_id)
+    r = c.get(f'/projects/{proj.id}/upload')
+    test("project page uses localized timestamps", b'data-utc=' in r.data)
+    r = c.get('/')
+    test("base layout ships the localizer script", b'time[data-utc]' in r.data)
+
+    print("\n=== Editor autosave + conflict guard ===")
+    r = c.get(f'/proposal/{prop.id}/edit')
+    test("editor ships autosave hooks",
+         b'pm-editor-draft-' in r.data and b'draft-restore-bar' in r.data)
+    test("editor carries base_version", b'name="base_version" value="1"' in r.data)
+
+    # Stale base_version (someone else saved) -> blocked, text preserved, no v2
+    r = c.post(f'/proposal/{prop.id}/edit', data={
+        'markdown_content': '# MINE conflict-edit PRESERVEME',
+        'change_summary': 'x', 'base_version': '0',
+    })
+    test("stale save blocked with text preserved",
+         r.status_code == 200 and b'PRESERVEME' in r.data
+         and b'Save blocked' in r.data)
+    test("no version created on conflict",
+         ProposalVersion.query.filter_by(proposal_id=prop.id).count() == 1)
+
+    r = c.post(f'/proposal/{prop.id}/edit', data={
+        'markdown_content': '# MINE clean save',
+        'change_summary': 'x', 'base_version': '1',
+    }, follow_redirects=True)
+    test("matching base_version saves v2",
+         ProposalVersion.query.filter_by(proposal_id=prop.id).count() == 2)
+
+    print("\n=== Accessibility ===")
+    r = c.get('/')
+    test("skip link present", b'skip-link' in r.data and b'id="main-content"' in r.data)
+    test("primary nav labeled", b'aria-label="Primary"' in r.data)
+    css = open('static/css/style.css', encoding='utf-8').read()
+    test("focus-visible styles exist", ':focus-visible' in css)
+    test("reduced-motion honored", 'prefers-reduced-motion' in css)
+    r = c.post('/settings', data={'display_name': 'Pia', 'email': pia.email,
+                                  'font_preference': 'Calibri',
+                                  'llm_model': pia.llm_model},
+               follow_redirects=True)
+    test("flash messages announce via role=alert",
+         b'role="alert"' in r.data and b'Settings saved.' in r.data)
+
+print("\n" + "=" * 50)
+print(f"Results: {passed} passed, {failed} failed out of {passed + failed} tests")
+sys.exit(0 if failed == 0 else 1)

--- a/test_p3_fixes.py
+++ b/test_p3_fixes.py
@@ -1,0 +1,257 @@
+"""Regression tests for the P3 journey-polish round.
+
+Jobs UX (cancel + discard guard), login-by-email + preserved form values,
+exact-match email lookups, generation quota hint + self-notification +
+honored PDF output format, batched scope updates, the action-items send gate,
+portal PDF / typed-name acceptance / first-view notification, money_compact,
+clarification int safety, posture inline edit routes, and the admin-only
+"Invite your team" wizard step.
+
+Standalone runner: python test_p3_fixes.py
+"""
+import io
+import os
+import sys
+from unittest.mock import patch
+
+os.environ['FLASK_SECRET_KEY'] = 'test-secret-key-12345'
+os.environ.pop('APP_ENV', None)
+
+import app as appmod
+from app import app, db
+import jobs
+from models import (BackgroundJob, ClarificationItem, EquipmentItem,
+                    Notification, Organization, Project, ProjectScope, Proposal,
+                    ProposalShare, ProposalVersion, ScopeItem,
+                    TravelExpenseRate, User)
+
+app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+app.config['TESTING'] = True
+
+passed = failed = 0
+
+
+def test(name, cond, detail=""):
+    global passed, failed
+    if cond:
+        passed += 1; print(f"  PASS: {name}")
+    else:
+        failed += 1; print(f"  FAIL: {name} - {detail}")
+
+
+def fake_generate(md_marker="V1MARKER"):
+    def _fake(rfp_text, **kwargs):
+        return {"proposal_markdown": f"# Proposal {md_marker}\n\nConfidence Score: 80%",
+                "action_items": [], "confidence_score": 80, "document_type": "RFP",
+                "vertical": kwargs.get("vertical") or "general",
+                "vertical_label": "General",
+                "generated_at": "2026-01-01T00:00:00+00:00"}
+    return _fake
+
+
+with app.app_context():
+    db.drop_all(); db.create_all()
+    c = app.test_client()
+    c.post('/signup', data={'username': 'zoe', 'email': 'zoe@corp.com',
+                            'password': 'password123', 'display_name': 'Zoe',
+                            'company_name': 'ZoeCorp'})
+    zoe = User.query.filter_by(username='zoe').first()
+    zoe.email_verified = True
+    db.session.commit()
+    org = db.session.get(Organization, zoe.org_id)
+
+    print("\n=== Login by email + preserved form values ===")
+    c.post('/logout')
+    r = c.post('/login', data={'username': 'ZOE@corp.com', 'password': 'password123'})
+    test("login with email (case-insensitive)", c.get('/').status_code == 200)
+    c.post('/logout')
+    r = c.post('/login', data={'username': 'zoe@corp.com', 'password': 'wrong'})
+    test("failed login preserves the typed identifier",
+         r.status_code == 200 and b'value="zoe@corp.com"' in r.data)
+    test("wildcard email can't match",
+         User.query.filter(appmod._email_matches('%')).first() is None)
+
+    r = c.post('/signup', data={'username': 'zoe', 'email': 'new@x.com',
+                                'password': 'password123', 'display_name': 'Newbie',
+                                'company_name': 'NewCo'})
+    test("signup error preserves typed values",
+         r.status_code == 200 and b'value="Newbie"' in r.data
+         and b'value="new@x.com"' in r.data)
+
+    c.post('/login', data={'username': 'zoe', 'password': 'password123'})
+
+    print("\n=== Job cancel + discard guard ===")
+    job = BackgroundJob(kind='draft_scope', user_id=zoe.id, org_id=zoe.org_id,
+                        status='queued', payload='{}')
+    db.session.add(job); db.session.commit()
+    c.post(f'/jobs/{job.id}/cancel')
+    db.session.refresh(job)
+    test("queued job cancels", job.status == 'canceled')
+    test("canceled job is never claimed", jobs._claim() is None)
+    r = c.get(f'/jobs/{job.id}/status.json')
+    test("status.json reports canceled", r.get_json().get('status') == 'canceled')
+
+    @jobs.register("p3_cancel_midrun")
+    def _h(payload, j):
+        # Simulates the user canceling while the handler is still running
+        j.status = 'canceled'
+        db.session.commit()
+        return {"redirect": "/should-be-discarded"}
+
+    job2 = BackgroundJob(kind='p3_cancel_midrun', user_id=zoe.id, org_id=zoe.org_id,
+                         status='queued', payload='{}')
+    db.session.add(job2); db.session.commit()
+    jobs._run_job(job2.id)
+    db.session.refresh(job2)
+    test("mid-run cancel discards the result",
+         job2.status == 'canceled' and 'discarded' not in (job2.result or ''))
+
+    print("\n=== Generation: quota hint, PDF format, self-notification ===")
+    c.post('/projects/new', data={'project_name': 'PolishBid', 'client_name': 'Acme'})
+    proj = Project.query.filter_by(name='PolishBid').first()
+    c.post(f'/projects/{proj.id}/upload', data={
+        'file_type': 'rfp',
+        'documents': (io.BytesIO(b'RFP for a data center EPMS project'), 'rfp.txt'),
+    }, content_type='multipart/form-data')
+
+    r = c.get(f'/projects/{proj.id}/upload')
+    test("generate card shows quota usage", b'used this month' in r.data)
+
+    with patch('app.generate_proposal', side_effect=fake_generate()):
+        c.post(f'/projects/{proj.id}/generate',
+               data={'vertical': 'general', 'output_format': 'pdf'})
+    prop = Proposal.query.filter_by(project_id=proj.id).first()
+    test("proposal generated", prop is not None)
+    from config.settings import GENERATED_DIR
+    test("output_format=pdf pre-renders the PDF",
+         bool(prop.pdf_file) and (GENERATED_DIR / prop.pdf_file).exists(),
+         f"pdf_file={prop.pdf_file!r}")
+    test("generator gets a completion notification",
+         Notification.query.filter_by(user_id=zoe.id, category='proposal_generated')
+         .filter(Notification.title.like('Your proposal is ready%')).count() == 1)
+
+    print("\n=== Batched scope updates ===")
+    def fake_scope(text, **kwargs):
+        return {"vertical": "general", "vertical_label": "General", "summary": "s",
+                "items": [{"item": f"Item {i}", "category": "general"} for i in range(4)]}
+    with patch('app.draft_scope_of_work', side_effect=fake_scope):
+        c.post(f'/projects/{proj.id}/scope/generate', data={'vertical': 'auto'})
+    scope = ProjectScope.query.filter_by(project_id=proj.id).first()
+    items = ScopeItem.query.filter_by(scope_id=scope.id).order_by(ScopeItem.sort_order).all()
+    test("scope drafted with 4 items", len(items) == 4)
+
+    c.post(f'/projects/{proj.id}/scope/approve')
+    db.session.refresh(scope)
+    test("scope approved", scope.status == 'approved')
+
+    # Keep only the first two items, in ONE post
+    c.post(f'/projects/{proj.id}/scope/batch-update',
+           data={'included': [items[0].id, items[1].id]})
+    statuses = [db.session.get(ScopeItem, i.id).status for i in items]
+    test("batch update applied all checkbox states",
+         statuses == ['included', 'included', 'removed', 'removed'], statuses)
+    db.session.refresh(scope)
+    test("batch change reopens an approved scope", scope.status == 'draft')
+    r = c.get(f'/projects/{proj.id}/scope')
+    test("scope page shows the review summary", b'AI kept' in r.data and b'struck' in r.data)
+
+    print("\n=== Action-items send gate ===")
+    db.session.add(ProposalVersion(proposal_id=prop.id, version_number=2,
+                                   markdown_content='# v2'))
+    prop.review_status = 'internally_approved'
+    prop.action_items_count = 3
+    db.session.commit()
+
+    c.post(f'/proposal/{prop.id}/submit-to-customer', data={})
+    db.session.refresh(prop)
+    test("submit blocked while action items open", prop.review_status == 'internally_approved')
+    c.post(f'/proposal/{prop.id}/share', data={})
+    test("share blocked while action items open",
+         ProposalShare.query.filter_by(proposal_id=prop.id).count() == 0)
+    c.post(f'/proposal/{prop.id}/share', data={'ack_action_items': '1'})
+    share = ProposalShare.query.filter_by(proposal_id=prop.id).first()
+    test("acknowledged share goes through", share is not None)
+    c.post(f'/proposal/{prop.id}/submit-to-customer', data={'ack_action_items': '1'})
+    db.session.refresh(prop)
+    test("acknowledged submit goes through",
+         prop.review_status in ('submitted_to_customer',))
+
+    print("\n=== Customer portal: PDF, first-view notify, typed acceptance ===")
+    r = c.get(f'/p/{share.token}')
+    test("portal renders with download link", b'Download PDF' in r.data)
+    db.session.refresh(share)
+    test("first view notifies the owner",
+         share.view_count == 1 and Notification.query.filter_by(
+             user_id=zoe.id, category='share_viewed').count() == 1)
+    c.get(f'/p/{share.token}')  # rapid re-view dedupes
+    test("rapid re-views don't re-notify",
+         Notification.query.filter_by(user_id=zoe.id, category='share_viewed').count() == 1)
+
+    r = c.get(f'/p/{share.token}/download.pdf')
+    test("portal PDF downloads", r.status_code == 200
+         and r.data[:4] == b'%PDF', f"status={r.status_code}")
+
+    c.post(f'/p/{share.token}/decision', data={'decision': 'accepted'})
+    db.session.refresh(share)
+    test("acceptance requires a typed name", share.decision == '')
+    c.post(f'/p/{share.token}/decision', data={
+        'decision': 'accepted', 'decider_name': 'Pat Buyer',
+        'decider_title': 'VP Procurement', 'note': 'Looks great'})
+    db.session.refresh(share)
+    test("typed-name acceptance recorded",
+         share.decision == 'accepted' and share.decided_by_name == 'Pat Buyer'
+         and share.decided_by_title == 'VP Procurement')
+    n = Notification.query.filter_by(user_id=zoe.id, category='customer_decision').first()
+    test("owner notified with the signer's name",
+         n is not None and 'Pat Buyer' in (n.message or ''))
+
+    print("\n=== Small fixes ===")
+    mc = appmod.money_compact_filter
+    test("money_compact humanizes values",
+         mc(850) == '$850' and mc(45000) == '$45k' and mc(1200000) == '$1.2M'
+         and mc(2500) == '$2.5k', f"{mc(850)}/{mc(45000)}/{mc(1200000)}/{mc(2500)}")
+
+    ci = ClarificationItem(project_id=proj.id, question='Q?', status='open')
+    db.session.add(ci); db.session.commit()
+    r = c.post(f'/clarifications/{ci.id}/update', data={'confidence_impact': 'not-a-number'})
+    test("bad confidence_impact no longer 500s", r.status_code in (200, 302))
+
+    eq = EquipmentItem(user_id=zoe.id, org_id=zoe.org_id, item_name='PLC', unit_cost=100.0)
+    tr = TravelExpenseRate(user_id=zoe.id, org_id=zoe.org_id, expense_type='Hotel', rate=150.0)
+    db.session.add_all([eq, tr]); db.session.commit()
+    c.post(f'/settings/edit-equipment-item/{eq.id}',
+           data={'item_name': 'PLC M580', 'unit_cost': '4,500.00', 'unit': 'each'})
+    db.session.refresh(eq)
+    test("equipment inline edit works", eq.item_name == 'PLC M580' and eq.unit_cost == 4500.0)
+    c.post(f'/settings/edit-travel-rate/{tr.id}',
+           data={'expense_type': 'Hotel (GSA)', 'travel_rate': '189'})
+    db.session.refresh(tr)
+    test("travel inline edit works", tr.expense_type == 'Hotel (GSA)' and tr.rate == 189.0)
+
+    # Cross-org isolation on the new edit routes
+    c.post('/logout')
+    c.post('/signup', data={'username': 'rival', 'email': 'rival@other.com',
+                            'password': 'password123', 'company_name': 'OtherCo'})
+    r = c.post(f'/settings/edit-equipment-item/{eq.id}', data={'item_name': 'HACKED'})
+    db.session.refresh(eq)
+    test("foreign org can't edit equipment", r.status_code == 404 and eq.item_name == 'PLC M580')
+
+    print("\n=== Wizard 'Invite your team' step ===")
+    prog_admin = appmod._setup_progress(zoe)
+    keys = [s['key'] for s in prog_admin['steps']]
+    test("admin wizard includes the team step", 'team' in keys)
+    team_step = next(s for s in prog_admin['steps'] if s['key'] == 'team')
+    test("team step pending while solo", team_step['done'] is False)
+
+    member = User(username='mem', email='mem@corp.com', org_id=zoe.org_id, role='proposal')
+    member.set_password('password123'); db.session.add(member); db.session.commit()
+    prog_admin = appmod._setup_progress(zoe)
+    team_step = next(s for s in prog_admin['steps'] if s['key'] == 'team')
+    test("team step done once a teammate exists", team_step['done'] is True)
+    prog_member = appmod._setup_progress(member)
+    test("non-admin wizard hides the team step",
+         'team' not in [s['key'] for s in prog_member['steps']])
+
+print("\n" + "=" * 50)
+print(f"Results: {passed} passed, {failed} failed out of {passed + failed} tests")
+sys.exit(0 if failed == 0 else 1)

--- a/test_security.py
+++ b/test_security.py
@@ -66,6 +66,10 @@ with app.app_context():
     (GENERATED_DIR / 'sec_dummy.md').unlink()
 
     print("\n=== Billing gates ===")
+    # Fresh workspaces carry a 14-day Pro trial (P2); these assertions test the
+    # FREE-plan limits, so end the trials first.
+    Organization.query.update({'trial_ends_at': None})
+    db.session.commit()
     billing.STRIPE_SECRET_KEY = ''
     login(c, 'bob')
     appmod.SELF_HOSTED = False

--- a/test_sso.py
+++ b/test_sso.py
@@ -1,0 +1,187 @@
+"""Tests for OIDC single sign-on.
+
+The security-critical account-resolution logic is pure and exhaustively tested.
+The full authorization-code callback is exercised with the two IdP HTTP calls
+(token exchange + userinfo) mocked, so state/CSRF handling, JIT provisioning,
+linking, and refusal paths are all covered without a live IdP. (Live-IdP
+verification is the one thing that still needs a real provider.)
+
+Standalone runner: python test_sso.py
+"""
+import os
+import sys
+from unittest.mock import patch
+
+os.environ['FLASK_SECRET_KEY'] = 'test-secret-key-12345'
+os.environ.pop('APP_ENV', None)
+
+import app as appmod
+import sso
+from app import app, db
+from models import Organization, User
+
+app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+app.config['TESTING'] = True
+
+passed = failed = 0
+
+
+def test(name, cond, detail=""):
+    global passed, failed
+    if cond:
+        passed += 1; print(f"  PASS: {name}")
+    else:
+        failed += 1; print(f"  FAIL: {name} - {detail}")
+
+
+# OIDC config used throughout (all https, all endpoints present)
+OIDC = {
+    "oidc_client_id": "cid", "oidc_client_secret": "csecret",
+    "oidc_auth_url": "https://idp.example.com/auth",
+    "oidc_token_url": "https://idp.example.com/token",
+    "oidc_userinfo_url": "https://idp.example.com/userinfo",
+    "oidc_scopes": "openid email profile", "oidc_button_label": "Sign in with Acme SSO",
+}
+
+
+def fake_cfg(key, default=""):
+    return OIDC.get(key, default)
+
+
+with app.app_context():
+    db.drop_all(); db.create_all()
+
+    print("\n=== configured() gating ===")
+    with patch.object(sso, "_cfg", side_effect=fake_cfg):
+        test("configured() true when all https endpoints set", sso.configured())
+        test("button label read from config", sso.button_label() == "Sign in with Acme SSO")
+        u = sso.authorize_url("https://app/cb", "xyz")
+        test("authorize_url carries client_id/state/redirect",
+             "client_id=cid" in u and "state=xyz" in u and "redirect_uri=https%3A%2F%2Fapp%2Fcb" in u)
+
+    def cfg_missing(key, default=""):
+        d = dict(OIDC); d["oidc_client_secret"] = ""
+        return d.get(key, default)
+    with patch.object(sso, "_cfg", side_effect=cfg_missing):
+        test("configured() false when a secret is missing", not sso.configured())
+
+    def cfg_http(key, default=""):
+        d = dict(OIDC); d["oidc_token_url"] = "http://idp.example.com/token"
+        return d.get(key, default)
+    with patch.object(sso, "_cfg", side_effect=cfg_http):
+        test("configured() false when an endpoint isn't https", not sso.configured())
+
+    print("\n=== resolve(): the security-critical branches ===")
+    # Seed: an org that claims acme.com with JIT, an existing user, a
+    # deactivated user, and an org that claims beta.com WITHOUT jit.
+    acme = Organization(name="Acme", sso_domain="acme.com", sso_jit=True)
+    beta = Organization(name="Beta", sso_domain="beta.com", sso_jit=False)
+    db.session.add_all([acme, beta]); db.session.flush()
+    existing = User(username="ann", email="ann@acme.com", org_id=acme.id, role="proposal")
+    existing.set_password("x"); db.session.add(existing)
+    dead = User(username="dan", email="dan@acme.com", org_id=acme.id, role="proposal", is_active=False)
+    dead.set_password("x"); db.session.add(dead)
+    db.session.commit()
+
+    test("unverified email refused",
+         sso.resolve("ann@acme.com", False).status == "unverified")
+    test("empty email refused", sso.resolve("", True).status == "unverified")
+    test("existing verified user -> ok",
+         sso.resolve("ANN@acme.com", True).status == "ok")
+    test("existing match is the right user",
+         sso.resolve("ann@acme.com", "true").user.id == existing.id)
+    test("deactivated user refused",
+         sso.resolve("dan@acme.com", True).status == "deactivated")
+    r = sso.resolve("new@acme.com", True)
+    test("unknown user at a JIT domain -> jit", r.status == "jit" and r.org.id == acme.id)
+    test("unknown user at a claimed-but-no-JIT domain -> no_account",
+         sso.resolve("new@beta.com", True).status == "no_account")
+    test("unknown user at an unclaimed domain -> no_account",
+         sso.resolve("stranger@nowhere.com", True).status == "no_account")
+
+    print("\n=== Full callback (mocked IdP HTTP) ===")
+    c = app.test_client()
+
+    def drive_callback(userinfo, tamper_state=False):
+        """Simulate: /sso/login (get state) then the IdP redirect to /sso/callback.
+        Always starts anonymous so each scenario is independent."""
+        c.post("/logout")
+        with patch.object(sso, "_cfg", side_effect=fake_cfg):
+            with c.session_transaction() as s:
+                s.pop("sso_state", None)
+            c.get("/sso/login")  # sets session['sso_state'] and 302s to IdP
+            with c.session_transaction() as s:
+                state = s.get("sso_state")
+            use_state = "WRONG" if tamper_state else state
+            with patch.object(sso, "exchange_code", return_value={"access_token": "at"}), \
+                 patch.object(sso, "fetch_userinfo", return_value=userinfo):
+                return c.get(f"/sso/callback?code=abc&state={use_state}",
+                             follow_redirects=False)
+
+    # CSRF: mismatched state is rejected and never logs in
+    r = drive_callback({"email": "ann@acme.com", "email_verified": True}, tamper_state=True)
+    test("state mismatch rejected", c.get("/").status_code == 302)
+
+    # Existing user links and logs in
+    r = drive_callback({"email": "ann@acme.com", "email_verified": True})
+    test("existing user signs in via SSO", c.get("/").status_code == 200)
+
+    # Unverified email from IdP is refused
+    r = drive_callback({"email": "ann@acme.com", "email_verified": False})
+    test("IdP-unverified email refused at callback", c.get("/").status_code == 302)
+
+    # JIT provisioning creates a member in the claimed org, then logs in
+    before = User.query.filter_by(org_id=acme.id).count()
+    r = drive_callback({"email": "jit@acme.com", "email_verified": True, "name": "Jit User"})
+    after = User.query.filter_by(org_id=acme.id).count()
+    test("JIT provisions a new member into the claimed org", after == before + 1)
+    newu = User.query.filter(appmod._email_matches("jit@acme.com")).first()
+    test("JIT user is active, verified, correct org/role",
+         newu and newu.org_id == acme.id and newu.role == "proposal"
+         and newu.email_verified is True and newu.is_active is True)
+    test("JIT user signed in", c.get("/").status_code == 200)
+    c.post("/logout")
+
+    # No workspace claims this domain -> refused, no user created
+    n_before = User.query.count()
+    r = drive_callback({"email": "someone@unclaimed.com", "email_verified": True})
+    test("unclaimed domain refused, no account created",
+         c.get("/").status_code == 302 and User.query.count() == n_before)
+
+    # Deactivated user refused even with a valid IdP identity
+    r = drive_callback({"email": "dan@acme.com", "email_verified": True})
+    test("deactivated user refused at callback", c.get("/").status_code == 302)
+
+    print("\n=== Login page button visibility ===")
+    with patch.object(sso, "_cfg", side_effect=fake_cfg):
+        r = c.get("/login")
+        test("SSO button shown when configured",
+             b'Sign in with Acme SSO' in r.data and b'/sso/login' in r.data)
+    r = c.get("/login")  # unconfigured
+    test("SSO button hidden when not configured", b'/sso/login' not in r.data)
+
+    print("\n=== /sso/login refuses when unconfigured ===")
+    r = c.get("/sso/login", follow_redirects=False)
+    test("sso/login redirects to password login when unconfigured",
+         r.status_code == 302 and "/login" in r.headers.get("Location", ""))
+
+    print("\n=== Admin domain claim ===")
+    c.post("/signup", data={"username": "boss", "email": "boss@corp.com",
+                            "password": "password123", "company_name": "CorpCo"})
+    boss = User.query.filter_by(username="boss").first()
+    org = db.session.get(Organization, boss.org_id)
+    c.post("/admin/sso", data={"sso_domain": "corp.com", "sso_jit": "1"})
+    db.session.refresh(org)
+    test("admin claims a domain with JIT", org.sso_domain == "corp.com" and org.sso_jit is True)
+    # Can't claim a domain another org already owns
+    r = c.post("/admin/sso", data={"sso_domain": "acme.com"})
+    db.session.refresh(org)
+    test("duplicate domain claim rejected", org.sso_domain == "corp.com")
+    # Bad domain format rejected
+    c.post("/admin/sso", data={"sso_domain": "not a domain"})
+    db.session.refresh(org)
+    test("malformed domain rejected", org.sso_domain == "corp.com")
+
+print("\n" + "=" * 50)
+print(f"Results: {passed} passed, {failed} failed out of {passed + failed} tests")
+sys.exit(0 if failed == 0 else 1)

--- a/twofa.py
+++ b/twofa.py
@@ -1,0 +1,95 @@
+"""Time-based one-time-password (TOTP) two-factor authentication.
+
+Standard RFC-6238 TOTP compatible with Google Authenticator, Authy, 1Password,
+etc. The per-user secret is stored ENCRYPTED at rest (crypto_util); backup
+codes are stored HASHED (like password-reset tokens) and are single-use.
+
+Pure-Python (pyotp + qrcode) — no system dependency.
+"""
+
+import base64
+import hashlib
+import io
+import json
+import secrets
+
+import pyotp
+
+# How many 30s steps on either side of "now" are accepted — tolerates a little
+# clock skew between the phone and the server without meaningfully widening the
+# brute-force window.
+_VALID_WINDOW = 1
+_BACKUP_CODE_COUNT = 10
+
+
+def new_secret() -> str:
+    return pyotp.random_base32()
+
+
+def provisioning_uri(secret: str, account: str, issuer: str = "Proposal Manager") -> str:
+    return pyotp.TOTP(secret).provisioning_uri(name=account, issuer_name=issuer)
+
+
+def qr_data_uri(otpauth_uri: str) -> str:
+    """A PNG data: URI of the otpauth QR code, safe to inline in an <img>."""
+    import qrcode
+    img = qrcode.make(otpauth_uri)
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    b64 = base64.b64encode(buf.getvalue()).decode("ascii")
+    return f"data:image/png;base64,{b64}"
+
+
+def verify_code(secret: str, code: str) -> bool:
+    """True if `code` is a currently-valid TOTP for `secret`."""
+    if not secret or not code:
+        return False
+    code = code.strip().replace(" ", "")
+    if not code.isdigit():
+        return False
+    try:
+        return pyotp.TOTP(secret).verify(code, valid_window=_VALID_WINDOW)
+    except Exception:
+        return False
+
+
+# --- Backup codes ----------------------------------------------------------
+
+def _normalize(code: str) -> str:
+    return (code or "").strip().lower().replace("-", "").replace(" ", "")
+
+
+def hash_backup_code(code: str) -> str:
+    return hashlib.sha256(_normalize(code).encode("utf-8")).hexdigest()
+
+
+def generate_backup_codes(n: int = _BACKUP_CODE_COUNT) -> tuple[list[str], str]:
+    """Return (plaintext_codes, json_of_hashes). The plaintext is shown to the
+    user ONCE; only the hashes are persisted."""
+    plaintext = []
+    for _ in range(n):
+        raw = secrets.token_hex(4)  # 8 hex chars
+        plaintext.append(f"{raw[:4]}-{raw[4:]}")
+    hashes = [hash_backup_code(c) for c in plaintext]
+    return plaintext, json.dumps(hashes)
+
+
+def consume_backup_code(stored_json: str, code: str) -> tuple[bool, str]:
+    """If `code` matches an unused backup hash, return (True, new_json) with
+    that hash removed (single-use). Otherwise (False, unchanged_json)."""
+    try:
+        hashes = json.loads(stored_json or "[]")
+    except (ValueError, TypeError):
+        hashes = []
+    h = hash_backup_code(code)
+    if h in hashes:
+        hashes.remove(h)
+        return True, json.dumps(hashes)
+    return False, stored_json or "[]"
+
+
+def backup_codes_remaining(stored_json: str) -> int:
+    try:
+        return len(json.loads(stored_json or "[]"))
+    except (ValueError, TypeError):
+        return 0

--- a/verticals/data_center/templates/mct_proposal_template.md
+++ b/verticals/data_center/templates/mct_proposal_template.md
@@ -1,4 +1,4 @@
-# MCT Proposal Template — E Tech Group Mission Critical Team
+# MCT Proposal Template — the Company Mission Critical Team
 
 ---
 
@@ -13,7 +13,7 @@ Re: [Project Name / Project Code] — [System Type: BMS / EPMS / BMS & EPMS]
 
 Dear [Client Contact Name],
 
-E Tech Group is pleased to present this proposal for the [Project Name] project. With over a decade of experience delivering mission critical automation and controls solutions for data center clients, E Tech Group brings proven expertise in Building Management Systems (BMS) and Electrical Power Monitoring Systems (EPMS) to meet the requirements outlined in your [RFP/RFQ].
+The Company is pleased to present this proposal for the [Project Name] project. With over a decade of experience delivering mission critical automation and controls solutions for data center clients, the Company brings proven expertise in Building Management Systems (BMS) and Electrical Power Monitoring Systems (EPMS) to meet the requirements outlined in your [RFP/RFQ].
 
 Our approach is grounded in our Zer0Defects™ Methodology — a rigorous quality framework that has enabled us to consistently deliver complex data center projects on time, within budget, and to the highest quality standards. We look forward to partnering with [Client/GC Name] on this important project.
 
@@ -44,7 +44,7 @@ The following documents were received as part of the bid package via [ACTION REQ
 |------|-------|-------|-------|
 | [ACTION REQUIRED: From RFP] | | | |
 
-### 1.4 E Tech Group Contacts
+### 1.4 The Company Contacts
 
 | Name | Title | Phone | Email |
 |------|-------|-------|-------|
@@ -56,13 +56,13 @@ The following documents were received as part of the bid package via [ACTION REQ
 
 ## Section 2: Executive Summary
 
-E Tech Group proposes to provide [BMS / EPMS / BMS and EPMS] services for the [Project Name] project located in [Project Location]. Our team of experienced mission critical professionals will deliver a comprehensive solution encompassing design, engineering, procurement, installation oversight, programming, commissioning, and project management.
+The Company proposes to provide [BMS / EPMS / BMS and EPMS] services for the [Project Name] project located in [Project Location]. Our team of experienced mission critical professionals will deliver a comprehensive solution encompassing design, engineering, procurement, installation oversight, programming, commissioning, and project management.
 
 ### Strategy for Project Completion
 
-E Tech Group's strategy for this project emphasizes [ACTION REQUIRED: BDM — Win theme: Quality / Experience / Value Engineering]. Our approach includes:
+The Company's strategy for this project emphasizes [ACTION REQUIRED: BDM — Win theme: Quality / Experience / Value Engineering]. Our approach includes:
 
-- **Proven Mission Critical Expertise** — E Tech Group has successfully delivered [controls/automation] solutions across hyperscale, colocation, and enterprise data center environments.
+- **Proven Mission Critical Expertise** — the Company has successfully delivered [controls/automation] solutions across hyperscale, colocation, and enterprise data center environments.
 - **Zer0Defects™ Methodology** — Our proprietary quality framework ensures rigorous QA/QC at every project milestone, minimizing rework and delivering systems that perform as designed from day one.
 - **Experienced Field Teams** — Our commissioning engineers and field technicians are trained specifically for mission critical environments, understanding the zero-tolerance nature of data center operations.
 
@@ -72,9 +72,9 @@ E Tech Group's strategy for this project emphasizes [ACTION REQUIRED: BDM — Wi
 
 ---
 
-## Section 3: E Tech Company Overview & Qualifications
+## Section 3: Company Overview & Qualifications
 
-[ACTION REQUIRED: Pull standard E Tech Company Overview boilerplate — includes:]
+[ACTION REQUIRED: Pull standard Company Overview boilerplate — includes:]
 - Company overview pages
 - Customer testimonial
 - Mission Critical Business Unit Overview
@@ -90,7 +90,7 @@ E Tech Group's strategy for this project emphasizes [ACTION REQUIRED: BDM — Wi
 
 ### 4.1 Scope Summary
 
-E Tech Group will provide the following services for the [Project Name] project:
+The Company will provide the following services for the [Project Name] project:
 
 [ACTION REQUIRED: AE — Derive from material takeoff. List major deliverables including:]
 - System type(s): [BMS / EPMS / both]
@@ -101,7 +101,7 @@ E Tech Group will provide the following services for the [Project Name] project:
 
 ### 4.2 Design, Documentation, and BIM Services
 
-E Tech Group will provide the following documentation deliverables:
+The Company will provide the following documentation deliverables:
 
 - As-built drawings and documentation
 - Panel shop drawings
@@ -116,7 +116,7 @@ E Tech Group will provide the following documentation deliverables:
 
 The following table summarizes material procurement responsibilities:
 
-| Category | E Tech Procured | Client/OFCI | LV Sub Procured |
+| Category | the Company Procured | Client/OFCI | LV Sub Procured |
 |----------|----------------|-------------|-----------------|
 | Instruments | [ACTION REQUIRED: AE] | | |
 | PLC Panels | [ACTION REQUIRED: AE] | | |
@@ -135,7 +135,7 @@ The following table summarizes material procurement responsibilities:
 
 ### 4.5 System Installation
 
-E Tech Group will engage [ACTION REQUIRED: Procurement — LV Sub partner name] as the Low Voltage Subcontractor for this project. The LV Sub scope includes:
+The Company will engage [ACTION REQUIRED: Procurement — LV Sub partner name] as the Low Voltage Subcontractor for this project. The LV Sub scope includes:
 
 - Procurement of raceways, conduit, and cables
 - Installation of conduit and accessories
@@ -143,7 +143,7 @@ E Tech Group will engage [ACTION REQUIRED: Procurement — LV Sub partner name] 
 - Physical mounting of EPMS control panels
 - Verification of proper wiring (continuity checks, labeling)
 
-E Tech Group retains responsibility for:
+The Company retains responsibility for:
 - Construction and field supervision
 - Programming
 - Point-to-point commissioning
@@ -152,7 +152,7 @@ E Tech Group retains responsibility for:
 
 ### 4.6 On-Site Support & Commissioning
 
-E Tech Group will provide on-site commissioning support including:
+The Company will provide on-site commissioning support including:
 
 - Point-to-point verification of all field devices
 - System functional testing
@@ -172,11 +172,11 @@ E Tech Group will provide on-site commissioning support including:
 
 ### 4.8 Change Management
 
-E Tech Group follows a formal Work Order Change Notice (WOCN) process for managing scope changes during project execution. All changes are documented, priced, and approved by the client before work proceeds.
+The Company follows a formal Work Order Change Notice (WOCN) process for managing scope changes during project execution. All changes are documented, priced, and approved by the client before work proceeds.
 
 ### 4.9 Safety & Security
 
-E Tech Group maintains a comprehensive safety program that meets or exceeds all OSHA requirements and client-specific safety standards. All field personnel are trained in site-specific safety protocols prior to mobilization.
+The Company maintains a comprehensive safety program that meets or exceeds all OSHA requirements and client-specific safety standards. All field personnel are trained in site-specific safety protocols prior to mobilization.
 
 [ACTION REQUIRED: AE — Note any client-specific safety requirements from the RFP, including safety staffing requirements]
 
@@ -222,7 +222,7 @@ E Tech Group maintains a comprehensive safety program that meets or exceeds all 
 
 ### Exclusions
 
-The following items are excluded from E Tech Group's scope unless specifically noted otherwise:
+The following items are excluded from the Company's scope unless specifically noted otherwise:
 
 [ACTION REQUIRED: AE — List exclusions. Common exclusions include:]
 - Life safety systems (fire alarm, fire suppression, hydrogen detection tied to life safety)
@@ -280,7 +280,7 @@ All pricing excludes applicable sales tax unless otherwise noted.
 
 ## Attachment: Terms and Conditions of Sale
 
-[ACTION REQUIRED: Insert standard E Tech Group Terms and Conditions of Sale boilerplate]
+[ACTION REQUIRED: Insert standard the Company Terms and Conditions of Sale boilerplate]
 
 ---
 

--- a/verticals/data_center/workflow.md
+++ b/verticals/data_center/workflow.md
@@ -1,6 +1,6 @@
 # Enhanced Overview of MCT AE Flow — AI Agent Training Document
 
-**Document Purpose:** This document provides the detailed workflow narrative for E Tech Group's Mission Critical Team (MCT) proposal process. It is designed to train an AI agent to understand each step of the process and produce first-draft MCT/Data Center proposals from RFPs and RFQs.
+**Document Purpose:** This document provides the detailed workflow narrative for the Company's Mission Critical Team (MCT) proposal process. It is designed to train an AI agent to understand each step of the process and produce first-draft MCT/Data Center proposals from RFPs and RFQs.
 
 **Version:** 3.0 — Updated to incorporate the MCT Proposal RACI Matrix (r2)
 **Date:** February 19, 2026
@@ -73,9 +73,9 @@ When the AE reviews the RFP package, they contact the BDM to get a better unders
 **Key Decisions at This Step:**
 
 - **System type:** Is this a BMS project, an EPMS project, or both?
-- **Delivery model:** Is this a turnkey bid (E Tech procures materials and executes) or labor-only?
+- **Delivery model:** Is this a turnkey bid (the Company procures materials and executes) or labor-only?
 - **Program assignment:** Is this a Hyperscale, OSI, or Colocation project? (The specific group assignment is determined by BD and the Program Directors — the AE group is not privy to that process.)
-- **Bid/No-Bid evaluation:** The team assesses whether to proceed based on: project timing, project size (megawatts), availability of low voltage contractors and other contractors at that location, whether the site location is suitable for E Tech Group's capabilities, and whether it logistically makes sense to pursue.
+- **Bid/No-Bid evaluation:** The team assesses whether to proceed based on: project timing, project size (megawatts), availability of low voltage contractors and other contractors at that location, whether the site location is suitable for the Company's capabilities, and whether it logistically makes sense to pursue.
 - **Win Theme:** The BDM is Responsible for defining the win theme for the pursuit — Quality, Experience, or Value Engineering. This strategic framing informs how the AI agent should position the entire proposal.
 
 **Output:** A go/no-go decision, an assigned pursuit team with defined roles per the RACI, a defined win theme, and an organized document repository with all RFP materials accessible to the team.
@@ -90,9 +90,9 @@ When the AE reviews the RFP package, they contact the BDM to get a better unders
 The full bid package from Step 1, specifically the design drawings and specifications. The AE reviews multiple drawing sets including: Mechanical, Architecture, Telecom, Controls and Automation, Electrical, Plumbing, and Technology. Most of these drawing sets are always present regardless of project type. Additional drawing sets may also be included (e.g., structural, civil, fire protection).
 
 **Process:**
-The AE physically goes sheet by sheet through every drawing set, marking up and counting every relevant item: instruments (temperature sensors, humidity sensors, flow meters, control valves, differential pressure sensors, etc.), panels (PLC panels, RIO panels, leak detection panels, etc.), gateways, VAV controllers, network devices, cable runs, and conduit paths. For each item, the AE documents: the quantity, its location in the facility, the signal type, wiring type, where it is wired to (destination panel), who is supplying it (E Tech, client/OFCI, or LV Sub), and who is installing it.
+The AE physically goes sheet by sheet through every drawing set, marking up and counting every relevant item: instruments (temperature sensors, humidity sensors, flow meters, control valves, differential pressure sensors, etc.), panels (PLC panels, RIO panels, leak detection panels, etc.), gateways, VAV controllers, network devices, cable runs, and conduit paths. For each item, the AE documents: the quantity, its location in the facility, the signal type, wiring type, where it is wired to (destination panel), who is supplying it (the Company, client/OFCI, or LV Sub), and who is installing it.
 
-The AE is identifying everything that falls within E Tech's controls scope — specifically anything related to Controls, BMS, BAS, EPMS, PMS, and low voltage electrical. Life-supporting devices such as fire or hydrogen sensors tied to life safety systems are excluded from E Tech's scope (though standalone hydrogen sensors for environmental monitoring may be included).
+The AE is identifying everything that falls within the Company's controls scope — specifically anything related to Controls, BMS, BAS, EPMS, PMS, and low voltage electrical. Life-supporting devices such as fire or hydrogen sensors tied to life safety systems are excluded from the Company's scope (though standalone hydrogen sensors for environmental monitoring may be included).
 
 The takeoff also captures:
 
@@ -114,9 +114,9 @@ Some AEs use the BMS/EPMS Automation Worksheet (a standardized scope matrix spre
 - Asking project engineers for help on technical questions that require specialized expertise.
 - Determining which contractors to send scope packages to for subcontractor bids. The Procurement Manager is responsible for recommending subcontractors. The BDM and BU Leadership decide which subcontractors will be asked to bid.
 
-**Typical Duration:** A day or two for E Tech's internal takeoff work, but the overall process can stretch to weeks depending on project size and the time required to get bids back from contractors (which is outside E Tech's control).
+**Typical Duration:** A day or two for the Company's internal takeoff work, but the overall process can stretch to weeks depending on project size and the time required to get bids back from contractors (which is outside the Company's control).
 
-**Output:** A completed material takeoff with instrument counts, panel counts, cable/conduit quantities, I/O counts, software requirements, and a categorized list of all scope items with ownership assignments (E Tech vs. OFCI vs. LV Sub). This data feeds directly into the estimate workbook (Step 6) and informs the LV Sub SOW (Step 3).
+**Output:** A completed material takeoff with instrument counts, panel counts, cable/conduit quantities, I/O counts, software requirements, and a categorized list of all scope items with ownership assignments (the Company vs. OFCI vs. LV Sub). This data feeds directly into the estimate workbook (Step 6) and informs the LV Sub SOW (Step 3).
 
 ---
 
@@ -130,9 +130,9 @@ The RFP specifications, design drawings, project timeline, and the material take
 **Process:**
 The AE drafts the Scope of Work for the Low Voltage Subcontractor (LV Sub), with the Operations Engineer jointly Responsible or Consulted on the content. This is a standalone deliverable — a detailed document that tells the LV Sub exactly what they are responsible for procuring, installing, and testing.
 
-Key information that flows from the RFP into the LV Sub SOW includes: specific cable color requirements, conduit fill rates, connector types, and safety staffing requirements. These requirements are always dictated by the client specifications — the AE does not set these based on E Tech standards.
+Key information that flows from the RFP into the LV Sub SOW includes: specific cable color requirements, conduit fill rates, connector types, and safety staffing requirements. These requirements are always dictated by the client specifications — the AE does not set these based on the Company standards.
 
-The scope boundary between E Tech and the LV Sub is consistent: the LV Sub does conduit and wire installation; E Tech does commissioning and programming. Specifically, the LV Sub is typically responsible for: procurement of raceways/conduit/cables, installation of conduit and accessories, cable pulling and termination, installation of EPMS control panels (physical mounting), and verification of proper wiring (continuity checks, labeling). E Tech retains responsibility for: construction/field supervision, programming, point-to-point commissioning, system commissioning support, and as-built documentation.
+The scope boundary between the Company and the LV Sub is consistent: the LV Sub does conduit and wire installation; the Company does commissioning and programming. Specifically, the LV Sub is typically responsible for: procurement of raceways/conduit/cables, installation of conduit and accessories, cable pulling and termination, installation of EPMS control panels (physical mounting), and verification of proper wiring (continuity checks, labeling). The Company retains responsibility for: construction/field supervision, programming, point-to-point commissioning, system commissioning support, and as-built documentation.
 
 **Review Gate:** After the AE finishes building the LV Sub SOW and prior to distribution for subcontractor bids, it is reviewed by an Ops Engineer and Procurement Manager.
 
@@ -168,15 +168,15 @@ This step is managed primarily by Procurement, with the Prop Mgr as the Accounta
 
 *Note: BDM, Ops Director, and Executive are conditionally consulted on sub selection (marked C* in the RACI), meaning their involvement depends on the project's strategic importance or size.*
 
-The team targets at least 2 bids, but sometimes only 1 is obtainable depending on location and availability. The format of LV Sub quotes varies depending on the GC or end user being supported. E Tech tries to have the LV contractor follow the same format or breakout structure that E Tech is being asked to provide to the customer.
+The team targets at least 2 bids, but sometimes only 1 is obtainable depending on location and availability. The format of LV Sub quotes varies depending on the GC or end user being supported. The Company tries to have the LV contractor follow the same format or breakout structure that the Company is being asked to provide to the customer.
 
 **Selection Criteria:**
-LV Sub selection is based on: local presence, price, customer knowledge (familiarity with the client's standards and expectations), and client preference. Sometimes multiple bids are not required if the right contractor is already identified. Especially if that contractor has recently completed a successful project with E Tech.
+LV Sub selection is based on: local presence, price, customer knowledge (familiarity with the client's standards and expectations), and client preference. Sometimes multiple bids are not required if the right contractor is already identified. Especially if that contractor has recently completed a successful project with the Company.
 
 **If Bids Come in Over Budget:**
-The Prop Mgr, AE, and Ops Eng go through bid leveling to identify scope gaps driving the price. The Procurement Mgr and Ops Director should be consulted. If the gap cannot be resolved and the bid number is firm, E Tech submits the scope as an alternate in the proposal so the customer can choose whether they want E Tech to carry that scope or not.
+The Prop Mgr, AE, and Ops Eng go through bid leveling to identify scope gaps driving the price. The Procurement Mgr and Ops Director should be consulted. If the gap cannot be resolved and the bid number is firm, the Company submits the scope as an alternate in the proposal so the customer can choose whether they want the Company to carry that scope or not.
 
-**What the AI Agent Should Know:** This step is always a "Needs Input" flag. The AI agent cannot solicit or evaluate LV Sub bids, but it CAN generate the LV Sub SOW (Step 3) and identify the information needed for the bid package. The AI agent should structure the proposal pricing section to accommodate the sub's cost. E Tech defines the sub's scope and any assumptions or exclusions agreed upon during bid leveling.
+**What the AI Agent Should Know:** This step is always a "Needs Input" flag. The AI agent cannot solicit or evaluate LV Sub bids, but it CAN generate the LV Sub SOW (Step 3) and identify the information needed for the bid package. The AI agent should structure the proposal pricing section to accommodate the sub's cost. The Company defines the sub's scope and any assumptions or exclusions agreed upon during bid leveling.
 
 **Output:** A selected LV Sub with a reviewed and leveled quote, ready to be input into the estimate workbook.
 
@@ -194,7 +194,7 @@ Per the RACI, Procurement is Responsible for sending RFQs to vendors and pricing
 
 Categories typically quoted include: instruments, panels, control hardware, software licenses, valves, breakers, gateways, IT/OT hardware, and MCCs (Motor Control Centers).
 
-The AE determines what to quote vs. what is OFCI based on what is specified in the RFQ or in site standards. Ops Eng is consulted and reviews the instrument take-offs. E Tech maintains a preferred supplier list; if the needed supplier is not on the list, the AE or Procurement will find an appropriate supplier. In some cases, the customer has mandated suppliers or approved manufacturer lists specified in the specifications.
+The AE determines what to quote vs. what is OFCI based on what is specified in the RFQ or in site standards. Ops Eng is consulted and reviews the instrument take-offs. The Company maintains a preferred supplier list; if the needed supplier is not on the list, the AE or Procurement will find an appropriate supplier. In some cases, the customer has mandated suppliers or approved manufacturer lists specified in the specifications.
 
 Supplier quotes typically come back as line items. The AE needs to map those line items into the customer's required workbook or breakout format — this is a manual process.
 
@@ -206,7 +206,7 @@ Supplier quotes typically come back as line items. The AE needs to map those lin
 | Panels | Procurement | Prop Mgr | AE |
 
 **Panel Shop Quoting:**
-The go-to rule is to quote using E Tech's internal panel shops. If the internal panel shops cannot meet the customer's timeline, E Tech will look to outsource. In very specific cases, E Tech's panel shops need to be approved by the end user, and if E Tech is at capacity and cannot get approval for an external shop, this may require a no-bid on the panel scope. When panel fabrication is OFCI (client-provided), it will be called out in the RFQ or in the standards.
+The go-to rule is to quote using the Company's internal panel shops. If the internal panel shops cannot meet the customer's timeline, the Company will look to outsource. In very specific cases, the Company's panel shops need to be approved by the end user, and if the Company is at capacity and cannot get approval for an external shop, this may require a no-bid on the panel scope. When panel fabrication is OFCI (client-provided), it will be called out in the RFQ or in the standards.
 
 **Expense Estimation (per the RACI — AE is Responsible for all):**
 The AE estimates the following expense categories, with the Prop Mgr as Accountable and Procurement Consulted where applicable:
@@ -283,18 +283,18 @@ The proposal is assembled by multiple team members according to the RACI. The Pr
 
 ### Proposal Sections — Ownership and Content Source
 
-**Cover Letter** — BDM is Responsible. Follows a standard, intentionally consistent format across all MCT proposals. Customized with the client/GC name, project name/code, system type (BMS/EPMS/both), and the names of E Tech signers. References E Tech's Zer0Defects™ Methodology and decade-plus data center experience. The AI agent can draft this from the standard template, flagging client name, project code, and signer names as "Needs Input."
+**Cover Letter** — BDM is Responsible. Follows a standard, intentionally consistent format across all MCT proposals. Customized with the client/GC name, project name/code, system type (BMS/EPMS/both), and the names of the Company signers. References the Company's Zer0Defects™ Methodology and decade-plus data center experience. The AI agent can draft this from the standard template, flagging client name, project code, and signer names as "Needs Input."
 
 **Section 1: Proposal Baseline** — Mostly templated, customized with project details.
 
 - 1.1 Revision History — Project-specific (version, date, initials, comments).
 - 1.2 Documents Provided by Client — Project-specific (list of RFP documents received, with the platform/source noted).
 - 1.3 Client Contacts — Project-specific (names, titles, phone, email from the RFP).
-- 1.4 E Tech Group Contacts — Project-specific (assigned E Tech team members — typically BD lead, Program Director, and Engineering Manager). Needs Input from BD/PD.
+- 1.4 the Company Contacts — Project-specific (assigned the Company team members — typically BD lead, Program Director, and Engineering Manager). Needs Input from BD/PD.
 
-**Section 2: Executive Summary** — Standard boilerplate, sometimes lightly adapted. Per the RACI, the BDM defines the win theme (Quality, Experience, or Value Engineering) which should inform the executive summary's emphasis. E Tech has a standard executive summary that is rarely customized significantly. Includes the Strategy for Project Completion narrative and the project schedule reference. The AI agent should use the standard boilerplate and adapt emphasis based on the win theme.
+**Section 2: Executive Summary** — Standard boilerplate, sometimes lightly adapted. Per the RACI, the BDM defines the win theme (Quality, Experience, or Value Engineering) which should inform the executive summary's emphasis. The Company has a standard executive summary that is rarely customized significantly. Includes the Strategy for Project Completion narrative and the project schedule reference. The AI agent should use the standard boilerplate and adapt emphasis based on the win theme.
 
-**Section 3: E Tech Company Overview & Qualifications** — Boilerplate — does not change. Per the RACI, the BDM is Responsible for the Corporate Overview, with the Ops Director and Executive Consulted. In practice, this section is pulled from the standard template verbatim. It includes the company overview pages, customer testimonial, and Mission Critical Business Unit Overview (Colo Program, Hyperscale Program, OSI Program descriptions, QA/QC audit results chart, and certifications). The AI agent should pull this section directly from the template.
+**Section 3: Company Overview & Qualifications** — Boilerplate — does not change. Per the RACI, the BDM is Responsible for the Corporate Overview, with the Ops Director and Executive Consulted. In practice, this section is pulled from the standard template verbatim. It includes the company overview pages, customer testimonial, and Mission Critical Business Unit Overview (Colo Program, Hyperscale Program, OSI Program descriptions, QA/QC audit results chart, and certifications). The AI agent should pull this section directly from the template.
 
 **Section 4: Project Scope** — Heavily customized per project. Multiple owners.
 
@@ -305,10 +305,10 @@ Per the RACI:
 Subsections include:
 - 4.1 Scope Summary — Derived from the takeoff; lists the major deliverables.
 - 4.2 Design, Documentation, and BIM Services — Lists as-built deliverables. Adjusted based on turnkey vs. labor-only.
-- 4.3 Materials - Scope of Supply — Directly from the material takeoff. Delineates E Tech-procured vs. OFCI vs. LV Sub-procured.
+- 4.3 Materials - Scope of Supply — Directly from the material takeoff. Delineates the Company-procured vs. OFCI vs. LV Sub-procured.
 - 4.4 PLC System Software, Execution — Derived from the specifications.
-- 4.5 System Installation — Describes the LV Sub scope and E Tech's supervision role. Names the selected LV Sub partner.
-- 4.6 On-Site Support & Commissioning — Describes E Tech's commissioning scope.
+- 4.5 System Installation — Describes the LV Sub scope and the Company's supervision role. Names the selected LV Sub partner.
+- 4.6 On-Site Support & Commissioning — Describes the Company's commissioning scope.
 - 4.7 Testing (SAT/IST) — Project-specific based on RFP requirements.
 - 4.8 Change Management — Standard WOCN boilerplate.
 - 4.9 Safety & Security — Standard boilerplate.
@@ -370,7 +370,7 @@ Per the RACI, the BDM is Responsible for this review. The Prop Mgr and AE are Co
 **Stage 4B — Executive Margin Review with CEO/CFO/CRO/President:**
 Per the RACI, the BDM is Responsible. The same Consulted parties apply. The executive team evaluates:
 - Labor margin vs. material margin vs. sub margin (the detailed breakdown, not just overall margin).
-- Strategic pricing considerations — whether to take a deeper cut on pricing to win a project with a strategically important client name, or to win a project where E Tech already has staff on a nearby project and the timing allows easy staff transfer.
+- Strategic pricing considerations — whether to take a deeper cut on pricing to win a project with a strategically important client name, or to win a project where the Company already has staff on a nearby project and the timing allows easy staff transfer.
 
 **Margin Review Deliverable:** Prior to the review, the BDM and Prop Mgr prepare a Margin Review PowerPoint presentation (BDM and Prop Mgr are jointly Responsible, AE is Consulted). The BDM is Responsible for scheduling the executive margin review.
 
@@ -394,7 +394,7 @@ Per the RACI, the BDM is Responsible for submitting the bid documents and propos
 The proposal is submitted primarily in PDF format, though some clients may require Word format. There are no known file size restrictions on the submission platforms. The BDM submits via the appropriate channel — online portal (Amazon Concentric, BuildingConnected, or other client-specific platforms) or email, depending on the client's requirements.
 
 **Submission Package:**
-Beyond the proposal document, the package may include (depending on customer requirements and E Tech's history with the client): bid response forms, pricing spreadsheets in the client's format, certificates (insurance, safety), personnel resumes, schedule files, and other supplemental documents.
+Beyond the proposal document, the package may include (depending on customer requirements and the Company's history with the client): bid response forms, pricing spreadsheets in the client's format, certificates (insurance, safety), personnel resumes, schedule files, and other supplemental documents.
 
 **File Naming Convention:**
 The recommended standard naming convention is: "MCT Proposal for [Client] [Project Code] [System Type]" — for example, "MCT Proposal for AWS ATL078 EPMS."
@@ -452,7 +452,7 @@ Based on this workflow and the RACI matrix, the AI agent's primary responsibilit
 - All pricing (never fabricated by the AI agent)
 - Labor rates (vary by project, region, and client)
 - Travel rotation assumptions and per diem rates
-- E Tech team member assignments and contact information
+- the Company team member assignments and contact information
 - Panel shop quotes and capacity decisions
 
 ### What the AI Agent Should Never Do

--- a/web_templates/_pagination.html
+++ b/web_templates/_pagination.html
@@ -1,0 +1,13 @@
+{# Pagination nav. Expects: page, total_pages, and pg_args (dict of extra query
+   params to preserve). Renders nothing when there's a single page. #}
+{% if total_pages and total_pages > 1 %}
+<nav class="pagination" aria-label="Pagination">
+    {% if page > 1 %}
+    <a class="btn btn-small btn-secondary" href="{{ url_for(request.endpoint, page=page-1, **pg_args) }}">&larr; Previous</a>
+    {% endif %}
+    <span class="pagination-status">Page {{ page }} of {{ total_pages }}</span>
+    {% if page < total_pages %}
+    <a class="btn btn-small btn-secondary" href="{{ url_for(request.endpoint, page=page+1, **pg_args) }}">Next &rarr;</a>
+    {% endif %}
+</nav>
+{% endif %}

--- a/web_templates/admin.html
+++ b/web_templates/admin.html
@@ -239,7 +239,7 @@
             <td><span class="role-badge role-{{ log.user.role or 'proposal' }}">{{ (log.user.role or 'proposal') | title }}</span></td>
             <td><span class="badge badge-activity">{{ log.action }}</span></td>
             <td class="td-desc">{{ log.detail[:100] }}{{ '...' if log.detail|length > 100 }}</td>
-            <td style="white-space:nowrap;">{{ log.created_at.strftime('%Y-%m-%d %H:%M') }}</td>
+            <td style="white-space:nowrap;">{{ log.created_at | localtime('full') }}</td>
         </tr>
         {% endfor %}
         </tbody>

--- a/web_templates/admin.html
+++ b/web_templates/admin.html
@@ -137,12 +137,15 @@
                 <th>Win Rate</th>
                 <th>Pipeline Value</th>
                 <th>Last Active</th>
+                <th></th>
             </tr>
         </thead>
         <tbody>
             {% for us in user_stats %}
-            <tr>
-                <td><strong>{{ us.user.display_name or us.user.username }}</strong></td>
+            <tr{% if us.user.is_active is sameas false %} style="opacity:0.55;"{% endif %}>
+                <td><strong>{{ us.user.display_name or us.user.username }}</strong>
+                    {% if us.user.is_active is sameas false %}<span class="chip chip-red" style="margin-left:6px;">Deactivated</span>{% endif %}
+                </td>
                 <td>{{ us.user.email }}</td>
                 <td>
                     {% if us.user.id == current_user.id %}
@@ -165,6 +168,20 @@
                 <td>{{ us.win_rate }}%</td>
                 <td>${{ "{:,.0f}".format(us.total_dollar) }}</td>
                 <td>{{ us.last_active or '&mdash;' }}</td>
+                <td>
+                    {% if us.user.id != current_user.id %}
+                    {% if us.user.is_active is sameas false %}
+                    <form method="post" action="{{ url_for('reactivate_user', user_id=us.user.id) }}" class="inline-form">
+                        <button type="submit" class="btn btn-small btn-secondary">Reactivate</button>
+                    </form>
+                    {% else %}
+                    <form method="post" action="{{ url_for('deactivate_user', user_id=us.user.id) }}" class="inline-form"
+                          onsubmit="return confirm('Deactivate {{ us.user.display_name or us.user.username }}? They will be signed out and can no longer access this workspace. Their seat is freed.');">
+                        <button type="submit" class="btn btn-small btn-danger">Deactivate</button>
+                    </form>
+                    {% endif %}
+                    {% endif %}
+                </td>
             </tr>
             {% endfor %}
         </tbody>

--- a/web_templates/admin.html
+++ b/web_templates/admin.html
@@ -188,6 +188,27 @@
     </table>
 </div>
 
+<!-- Single sign-on -->
+<div class="card" id="sso">
+    <h2>Single Sign-On (SSO)</h2>
+    {% if sso_configured %}
+    <p class="card-desc">Claim your company's email domain so teammates sign in through your identity provider. With auto-provisioning on, a first-time user at that domain is added to this workspace automatically.</p>
+    <form method="post" action="{{ url_for('update_sso_domain') }}" style="display:flex; gap:12px; flex-wrap:wrap; align-items:flex-end;">
+        <div class="form-group" style="margin:0; min-width:240px;">
+            <label for="sso_domain">Email domain</label>
+            <input type="text" id="sso_domain" name="sso_domain" placeholder="acme.com" value="{{ org.sso_domain if org else '' }}">
+        </div>
+        <div class="form-group" style="margin:0;">
+            <label class="checkbox-label"><input type="checkbox" name="sso_jit" value="1" {{ 'checked' if org and org.sso_jit }}> Auto-provision new members (JIT)</label>
+        </div>
+        <button type="submit" class="btn btn-secondary">Save SSO settings</button>
+    </form>
+    <p class="form-hint" style="margin-top:8px;">Users still need to exist here (or be auto-provisioned) — SSO never creates a brand-new workspace. Deactivated accounts are refused.</p>
+    {% else %}
+    <p class="card-desc">Single sign-on isn't configured on this deployment yet. The platform operator sets up the identity provider (OIDC) in Platform-Admin, after which you can claim your email domain here.</p>
+    {% endif %}
+</div>
+
 <!-- Integrations -->
 <div class="card" id="integrations">
     <h2>Integrations</h2>

--- a/web_templates/base.html
+++ b/web_templates/base.html
@@ -217,6 +217,25 @@
     {% if current_user.is_authenticated %}
     <script>
     (function(){
+        // Flash messages: dismiss button + auto-fade for successes (errors stay)
+        document.querySelectorAll(".flash-messages .flash").forEach(function(el){
+            var btn = document.createElement("button");
+            btn.type = "button";
+            btn.className = "flash-close";
+            btn.setAttribute("aria-label", "Dismiss message");
+            btn.innerHTML = "&times;";
+            btn.addEventListener("click", function(){ el.remove(); });
+            el.appendChild(btn);
+            if (el.classList.contains("flash-success")) {
+                setTimeout(function(){
+                    el.style.transition = "opacity 0.6s";
+                    el.style.opacity = "0";
+                    setTimeout(function(){ el.remove(); }, 700);
+                }, 6000);
+            }
+        });
+    })();
+    (function(){
         // Localize <time data-utc> elements to the viewer's timezone.
         document.querySelectorAll("time[data-utc]").forEach(function(el){
             var d = new Date(el.getAttribute("data-utc"));

--- a/web_templates/base.html
+++ b/web_templates/base.html
@@ -18,7 +18,7 @@
             </a>
         </div>
 
-        {% set workspace_name = current_user.company_name or (current_user.display_name or current_user.username) %}
+        {% set workspace_name = nav_org_name or current_user.company_name or (current_user.display_name or current_user.username) %}
         <a class="workspace-chip" href="{{ url_for('settings') }}" title="Workspace settings">
             <span class="workspace-chip-avatar">{{ workspace_name[:1] | upper }}</span>
             <span class="workspace-chip-name">{{ workspace_name }}</span>
@@ -87,7 +87,7 @@
         <div class="sidebar-footer">
             <div class="sidebar-user">
                 <span class="sidebar-user-name">{{ current_user.display_name or current_user.username }}</span>
-                <span class="sidebar-user-company">{{ current_user.company_name or '' }}</span>
+                <span class="sidebar-user-company">{{ nav_org_name or '' }}</span>
             </div>
             <form method="POST" action="{{ url_for('logout') }}" style="margin:0">
                 <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">

--- a/web_templates/base.html
+++ b/web_templates/base.html
@@ -10,6 +10,7 @@
 </head>
 <body{% if not current_user.is_authenticated %} class="auth-page"{% endif %}>
     {% if current_user.is_authenticated %}
+    <a class="skip-link" href="#main-content">Skip to main content</a>
     <aside class="sidebar">
         <div class="sidebar-brand">
             <a href="{{ url_for('dashboard') }}">
@@ -24,6 +25,14 @@
             <span class="workspace-chip-name">{{ workspace_name }}</span>
         </a>
 
+        {% if nav_trial_days and nav_trial_days > 0 %}
+        <a class="setup-nav-link" href="{{ url_for('billing_page') }}" title="Pro trial — {{ nav_trial_days }} day(s) left">
+            <span class="sidebar-icon">&#9201;</span>
+            <span>Pro trial</span>
+            <span class="nav-count-badge">{{ nav_trial_days }}d left</span>
+        </a>
+        {% endif %}
+
         {% if setup_progress and not setup_progress.complete %}
         <a class="setup-nav-link" href="{{ url_for('setup_wizard') }}">
             <span class="sidebar-icon">&#10024;</span>
@@ -32,7 +41,7 @@
         </a>
         {% endif %}
 
-        <nav class="sidebar-nav">
+        <nav class="sidebar-nav" aria-label="Primary">
             <span class="side-group-label">Work</span>
             <a href="{{ url_for('dashboard') }}" class="sidebar-link{% if request.endpoint == 'dashboard' %} active{% endif %}">
                 <span class="sidebar-icon"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="7" rx="1.5"/><rect x="14" y="3" width="7" height="7" rx="1.5"/><rect x="3" y="14" width="7" height="7" rx="1.5"/><rect x="14" y="14" width="7" height="7" rx="1.5"/></svg></span>
@@ -102,7 +111,7 @@
     <div class="main-wrapper">
         <header class="topbar">
             <button class="sidebar-toggle" id="sidebar-toggle" type="button" aria-label="Toggle sidebar">&#9776;</button>
-            <nav class="breadcrumb">
+            <nav class="breadcrumb" aria-label="Breadcrumb">
                 {% block breadcrumb %}<span class="crumb-current">Workspace</span>{% endblock %}
             </nav>
             <form class="topbar-search" method="get" action="{{ url_for('search') }}">
@@ -144,7 +153,7 @@
                 </div>
             </div>
         </header>
-        <main class="main-content">
+        <main class="main-content" id="main-content">
             {% if current_user.is_authenticated and not current_user.email_verified %}
             <div class="flash flash-info verify-banner">
                 Please verify your email address ({{ current_user.email }}).
@@ -158,7 +167,7 @@
             {% if messages %}
             <div class="flash-messages">
                 {% for category, message in messages %}
-                <div class="flash flash-{{ category }}">{{ message }}</div>
+                <div class="flash flash-{{ category }}" role="alert">{{ message }}</div>
                 {% endfor %}
             </div>
             {% endif %}
@@ -207,6 +216,22 @@
     {% block scripts %}{% endblock %}
     {% if current_user.is_authenticated %}
     <script>
+    (function(){
+        // Localize <time data-utc> elements to the viewer's timezone.
+        document.querySelectorAll("time[data-utc]").forEach(function(el){
+            var d = new Date(el.getAttribute("data-utc"));
+            if (isNaN(d)) return;
+            var style = el.getAttribute("data-style") || "dt";
+            var opts;
+            if (style === "date") opts = {month:"short", day:"numeric", year:"numeric"};
+            else if (style === "full") opts = {month:"short", day:"numeric", year:"numeric", hour:"2-digit", minute:"2-digit"};
+            else opts = {month:"short", day:"numeric", hour:"2-digit", minute:"2-digit"};
+            try {
+                el.textContent = d.toLocaleString(undefined, opts);
+                el.title = d.toLocaleString();
+            } catch (e) { /* keep UTC fallback */ }
+        });
+    })();
     (function(){
         // CSRF: inject token into every same-origin POST form and fetch call
         var csrfToken = (document.querySelector('meta[name="csrf-token"]') || {}).content || "";

--- a/web_templates/billing.html
+++ b/web_templates/billing.html
@@ -8,6 +8,18 @@
     <p class="page-subtitle">{{ org.name if org else 'Workspace' }} — you're on the <strong>{{ current_plan.name }}</strong> plan.</p>
 </section>
 
+{% if trial_active %}
+<div class="flash flash-info">
+    <strong>Pro trial active — {{ trial_days }} day{{ 's' if trial_days != 1 }} left.</strong>
+    You have Pro limits ({{ plans['pro'].limits.generations_per_month }} AI proposals/mo,
+    {{ plans['pro'].limits.seats }} seats) until
+    {{ trial_ends.strftime('%B %d, %Y') if trial_ends else 'the trial ends' }},
+    then your workspace returns to Free limits. Upgrade below to keep them.
+</div>
+{% elif current_plan_key == 'free' and org and org.trial_ends_at %}
+<div class="flash flash-info">Your Pro trial has ended — you're on Free limits. Upgrade below to restore Pro capacity.</div>
+{% endif %}
+
 {% if not stripe_enabled %}
 <div class="flash flash-info">Payments aren't configured on this deployment, so plan changes apply immediately without checkout.</div>
 {% endif %}

--- a/web_templates/clarification_register.html
+++ b/web_templates/clarification_register.html
@@ -244,7 +244,7 @@
             <td colspan="7" style="background:var(--gray-50);font-size:13px;padding:8px 12px;">
                 <strong>Response:</strong> {{ item.response }}
                 {% if item.responded_at %}
-                <span style="color:var(--gray-500);"> &mdash; {{ item.responded_at.strftime('%Y-%m-%d %H:%M') }}</span>
+                <span style="color:var(--gray-500);"> &mdash; {{ item.responded_at | localtime('full') }}</span>
                 {% endif %}
             </td>
         </tr>

--- a/web_templates/dashboard.html
+++ b/web_templates/dashboard.html
@@ -82,7 +82,7 @@
                     </div>
                     <div class="focus-item-sub">
                         {% if item.due_str %}<span class="{{ 'focus-overdue' if item.overdue }}">{{ item.due_str }}</span>{% if item.sub or item.value %} &middot; {% endif %}{% endif %}
-                        {% if item.value %}${{ "{:,.1f}".format(item.value / 1000000) }}M{% if item.sub %} &middot; {% endif %}{% endif %}
+                        {% if item.value %}{{ item.value | money_compact }}{% if item.sub %} &middot; {% endif %}{% endif %}
                         {{ item.sub }}
                     </div>
                 </div>
@@ -94,7 +94,7 @@
         </ul>
         <div class="focus-footer">
             <span>Showing <strong id="focus-shown">{{ focus_items | length }}</strong> of {{ focus_items | length }} open item{{ 's' if focus_items | length != 1 }}
-                {% if combined_exposure %} &middot; <strong>${{ "{:,.1f}".format(combined_exposure / 1000000) }}M</strong> combined exposure{% endif %}
+                {% if combined_exposure %} &middot; <strong>{{ combined_exposure | money_compact }}</strong> combined exposure{% endif %}
             </span>
             <a href="{{ url_for('proposals_list') }}">See all proposals &rarr;</a>
         </div>

--- a/web_templates/document_library.html
+++ b/web_templates/document_library.html
@@ -134,7 +134,7 @@
 <!-- Documents Table -->
 {% if documents %}
 <div class="card">
-    <h2>Documents ({{ documents | length }})</h2>
+    <h2>Documents ({{ filtered_count if filtered_count is defined else documents | length }})</h2>
     <div class="doc-table-wrap">
         <table class="doc-table">
             <thead>
@@ -214,6 +214,10 @@
             </tbody>
         </table>
     </div>
+    {% set pg_args = {'q': q, 'type': filter_type, 'project': filter_project,
+                      'tag': filter_tag, 'status': filter_status,
+                      'sort': sort_by, 'reference': show_reference} %}
+    {% include "_pagination.html" %}
 </div>
 {% else %}
 <div class="empty-state">
@@ -260,7 +264,7 @@
                     <span>{{ prop.confidence_score }}%</span>
                 </div>
             </td>
-            <td class="doc-date">{{ prop.generated_at.strftime('%Y-%m-%d %H:%M') if prop.generated_at else 'N/A' }}</td>
+            <td class="doc-date">{% if prop.generated_at %}{{ prop.generated_at | localtime('full') }}{% else %}N/A{% endif %}</td>
             <td>
                 <div class="doc-actions">
                     <a href="{{ url_for('view_proposal', proposal_id=prop.id) }}" class="btn btn-small btn-primary">View</a>

--- a/web_templates/job_status.html
+++ b/web_templates/job_status.html
@@ -4,16 +4,23 @@
 
 {% block content %}
 <div class="page-narrow">
-  <div class="card job-card" id="job-card" data-job-id="{{ job.id }}">
+  <div class="card job-card" id="job-card" data-job-id="{{ job.id }}"
+       data-created="{{ job.created_at.strftime('%Y-%m-%dT%H:%M:%SZ') if job.created_at else '' }}">
     <div class="job-spinner" id="job-spinner"></div>
     <h1 class="job-title" id="job-title">Working on it…</h1>
     <p class="job-phase" id="job-phase">{{ job.message or "Queued — starting shortly." }}</p>
+    <p class="form-hint" id="job-elapsed" aria-live="off"></p>
     <div class="job-steps" id="job-steps">
       <span class="job-step" data-phase="reading">Read documents</span>
       <span class="job-step" data-phase="drafting">Draft with AI</span>
       <span class="job-step" data-phase="saving">Format &amp; save</span>
     </div>
     <div class="job-error" id="job-error" style="display:none"></div>
+    <form method="post" action="{{ url_for('job_cancel', job_id=job.id) }}" id="job-cancel-form"
+          style="margin-top:12px;{% if job.status not in ('queued', 'running') %} display:none;{% endif %}"
+          onsubmit="return confirm('Cancel this job? Any AI work in progress will be discarded.');">
+      <button type="submit" class="btn btn-small btn-secondary">Cancel</button>
+    </form>
     <div class="job-actions" id="job-actions" style="display:none">
       <a href="{{ url_for('dashboard') }}" class="btn btn-secondary">Back to dashboard</a>
     </div>
@@ -29,7 +36,21 @@
   var errorEl = document.getElementById("job-error");
   var actionsEl = document.getElementById("job-actions");
   var spinner = document.getElementById("job-spinner");
+  var cancelForm = document.getElementById("job-cancel-form");
   var order = ["reading", "drafting", "saving"];
+
+  // Elapsed timer
+  var elapsedEl = document.getElementById("job-elapsed");
+  var startedAt = new Date(card.getAttribute("data-created"));
+  var elapsedTimer = null;
+  function tickElapsed(){
+    if (isNaN(startedAt)) return;
+    var s = Math.max(0, Math.floor((Date.now() - startedAt.getTime()) / 1000));
+    elapsedEl.textContent = "Elapsed " + Math.floor(s / 60) + ":" + String(s % 60).padStart(2, "0");
+  }
+  tickElapsed();
+  elapsedTimer = setInterval(tickElapsed, 1000);
+  function stopElapsed(){ if (elapsedTimer) clearInterval(elapsedTimer); }
 
   function markSteps(phase){
     var idx = order.indexOf(phase);
@@ -48,12 +69,25 @@
         if (d.message) phaseEl.textContent = d.message;
         if (d.phase) markSteps(d.phase);
         if (d.status === "done"){
+          stopElapsed();
+          if (cancelForm) cancelForm.style.display = "none";
           titleEl.textContent = "Done!";
           phaseEl.textContent = "Redirecting to your proposal…";
           window.location.href = d.redirect;
           return;
         }
+        if (d.status === "canceled"){
+          stopElapsed();
+          if (cancelForm) cancelForm.style.display = "none";
+          spinner.style.display = "none";
+          titleEl.textContent = "Canceled";
+          phaseEl.textContent = "This job was canceled — nothing was saved or charged.";
+          actionsEl.style.display = "block";
+          return;
+        }
         if (d.status === "failed"){
+          stopElapsed();
+          if (cancelForm) cancelForm.style.display = "none";
           spinner.style.display = "none";
           titleEl.textContent = "Something went wrong";
           phaseEl.style.display = "none";

--- a/web_templates/login.html
+++ b/web_templates/login.html
@@ -42,6 +42,10 @@
                 </div>
                 <button type="submit" class="btn btn-primary btn-large" style="background: var(--sea-800);">Sign in</button>
             </form>
+            {% if sso_enabled %}
+            <div class="auth-divider"><span>or</span></div>
+            <a href="{{ url_for('sso_login') }}" class="btn btn-secondary btn-large" style="width:100%; text-align:center;">{{ sso_label }}</a>
+            {% endif %}
             <p class="auth-footer"><a href="{{ url_for('forgot_password') }}">Forgot your password?</a></p>
             <p class="auth-footer">Don't have an account? <a href="{{ url_for('signup') }}">Register</a></p>
         </div>

--- a/web_templates/login.html
+++ b/web_templates/login.html
@@ -27,8 +27,8 @@
             <form method="post" action="{{ url_for('login') }}">
                 <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                 <div class="form-group">
-                    <label for="username">Username</label>
-                    <input type="text" id="username" name="username" required autofocus autocomplete="username">
+                    <label for="username">Username or email</label>
+                    <input type="text" id="username" name="username" required autofocus autocomplete="username" value="{{ ident or '' }}">
                 </div>
                 <div class="form-group">
                     <label for="password">Password</label>

--- a/web_templates/login_2fa.html
+++ b/web_templates/login_2fa.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Two-Factor Verification &mdash; {{ app_name }}</title>
+    <link rel="icon" type="image/svg+xml" href="{{ url_for('static', filename='img/pm-logo-mark.svg') }}">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
+</head>
+<body class="auth-page">
+    <div class="auth-container">
+        <div class="auth-brand">
+            <img src="{{ url_for('static', filename='img/pm-logo-full.svg') }}" alt="{{ app_name }}">
+            <p class="auth-tagline">AI-Powered Proposal Platform</p>
+        </div>
+        <div class="auth-card">
+            <h2 class="auth-heading">Two-factor verification</h2>
+            <p class="auth-sub">Enter the 6-digit code from your authenticator app, or a backup code.</p>
+
+            {% with messages = get_flashed_messages(with_categories=true) %}
+            {% if messages %}{% for category, message in messages %}
+            <div class="flash flash-{{ category }}" role="alert">{{ message }}</div>
+            {% endfor %}{% endif %}
+            {% endwith %}
+
+            <form method="post" action="{{ url_for('login_2fa') }}">
+                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                <div class="form-group">
+                    <label for="code">Authentication code</label>
+                    <input type="text" id="code" name="code" required autofocus autocomplete="one-time-code"
+                           inputmode="numeric" placeholder="123456 or a backup code"
+                           style="letter-spacing: 2px;">
+                </div>
+                <button type="submit" class="btn btn-primary btn-large" style="background: var(--sea-800);">Verify</button>
+            </form>
+            <p class="auth-footer"><a href="{{ url_for('login') }}">Cancel and sign in again</a></p>
+        </div>
+        <p class="auth-below">{{ app_footer }}</p>
+    </div>
+</body>
+</html>

--- a/web_templates/notifications.html
+++ b/web_templates/notifications.html
@@ -25,7 +25,7 @@
         <div class="notif-full-body">
             <div class="notif-full-title">{{ n.title }}</div>
             {% if n.message %}<div class="notif-full-msg">{{ n.message }}</div>{% endif %}
-            <div class="notif-full-time">{{ n.created_at.strftime('%b %d, %Y at %H:%M') }}</div>
+            <div class="notif-full-time">{{ n.created_at | localtime('full') }}</div>
         </div>
         <div class="notif-full-actions">
             {% if n.link %}<a href="{{ n.link }}" class="btn btn-small btn-primary">View</a>{% endif %}

--- a/web_templates/portal.html
+++ b/web_templates/portal.html
@@ -42,9 +42,14 @@
         {% if share.decision %}
         <div class="decided-banner decided-{{ share.decision }}">
             You {{ 'accepted' if share.decision == 'accepted' else 'declined' }} this proposal
+            {% if share.decided_by_name %}as {{ share.decided_by_name }}{% if share.decided_by_title %} ({{ share.decided_by_title }}){% endif %}{% endif %}
             {{ 'on ' + share.decided_at.strftime('%B %d, %Y') if share.decided_at else '' }}.
         </div>
         {% endif %}
+
+        <p style="text-align:right; margin: 0 0 10px;">
+            <a class="btn btn-secondary" href="{{ url_for('portal_pdf', token=share.token) }}">&#8681; Download PDF</a>
+        </p>
 
         <div class="portal-doc">
             {{ proposal_html | safe }}
@@ -55,18 +60,20 @@
             {% if share.allow_decision %}
             <h3>Your decision</h3>
             <p>Ready to move forward, or need changes?</p>
-            <div class="decision-row">
-                <form method="post" action="{{ url_for('portal_decision', token=share.token) }}">
-                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-                    <input type="hidden" name="decision" value="accepted">
-                    <button type="submit" class="btn btn-primary">Accept proposal</button>
-                </form>
-                <form method="post" action="{{ url_for('portal_decision', token=share.token) }}">
-                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-                    <input type="hidden" name="decision" value="declined">
-                    <button type="submit" class="btn btn-secondary">Decline</button>
-                </form>
-            </div>
+            <form method="post" action="{{ url_for('portal_decision', token=share.token) }}">
+                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                <div class="decision-row" style="margin-bottom:10px;">
+                    <input type="text" name="decider_name" placeholder="Your full name (required to accept)"
+                           style="flex:1; min-width:200px; padding:9px 11px; border:1px solid #ccc; border-radius:8px; font:inherit;">
+                    <input type="text" name="decider_title" placeholder="Title (optional)"
+                           style="flex:1; min-width:150px; padding:9px 11px; border:1px solid #ccc; border-radius:8px; font:inherit;">
+                </div>
+                <textarea name="note" placeholder="Optional note to the team…" style="min-height:60px; margin-bottom:10px;"></textarea>
+                <div class="decision-row">
+                    <button type="submit" name="decision" value="accepted" class="btn btn-primary">Accept proposal</button>
+                    <button type="submit" name="decision" value="declined" class="btn btn-secondary">Decline</button>
+                </div>
+            </form>
             {% endif %}
 
             {% if share.allow_comments %}

--- a/web_templates/posture.html
+++ b/web_templates/posture.html
@@ -272,9 +272,22 @@
                     <td>${{ "%.2f"|format(r.hourly_rate) }}</td>
                     <td>{{ "$%.2f"|format(r.overtime_rate) if r.overtime_rate else '—' }}</td>
                     <td class="td-desc">{{ r.description or '—' }}</td>
-                    <td>
+                    <td style="white-space:nowrap;">
+                        <button type="button" class="btn btn-small btn-secondary row-edit-btn" data-target="edit-sr-{{ r.id }}">Edit</button>
                         <form method="post" action="{{ url_for('delete_staff_role', role_id=r.id) }}" class="inline-form">
                             <button type="submit" class="btn btn-small btn-danger" onclick="return confirm('Delete this staff role?')">Delete</button>
+                        </form>
+                    </td>
+                </tr>
+                <tr id="edit-sr-{{ r.id }}" class="inline-edit-row" style="display:none;">
+                    <td colspan="6">
+                        <form method="post" action="{{ url_for('edit_staff_role', role_id=r.id) }}" class="inline-form" style="display:flex; gap:8px; flex-wrap:wrap; align-items:flex-end;">
+                            <label style="font-size:11px;">Role<br><input type="text" name="role_name" value="{{ r.role_name }}"></label>
+                            <label style="font-size:11px;">Category<br><input type="text" name="category" value="{{ r.category }}"></label>
+                            <label style="font-size:11px;">Hourly $<br><input type="number" step="0.01" min="0" name="hourly_rate" value="{{ r.hourly_rate }}" style="width:100px;"></label>
+                            <label style="font-size:11px;">OT $<br><input type="number" step="0.01" min="0" name="overtime_rate" value="{{ r.overtime_rate or '' }}" style="width:100px;"></label>
+                            <label style="font-size:11px; flex:1;">Description<br><input type="text" name="description" value="{{ r.description }}" style="width:100%;"></label>
+                            <button type="submit" class="btn btn-small btn-primary">Save</button>
                         </form>
                     </td>
                 </tr>
@@ -402,9 +415,23 @@
                     <td>{{ e.manufacturer or '—' }}</td>
                     <td>${{ "%.2f"|format(e.unit_cost) }}</td>
                     <td>{{ e.unit }}</td>
-                    <td>
+                    <td style="white-space:nowrap;">
+                        <button type="button" class="btn btn-small btn-secondary row-edit-btn" data-target="edit-eq-{{ e.id }}">Edit</button>
                         <form method="post" action="{{ url_for('delete_equipment_item', item_id=e.id) }}" class="inline-form">
                             <button type="submit" class="btn btn-small btn-danger" onclick="return confirm('Delete this item?')">Delete</button>
+                        </form>
+                    </td>
+                </tr>
+                <tr id="edit-eq-{{ e.id }}" class="inline-edit-row" style="display:none;">
+                    <td colspan="7">
+                        <form method="post" action="{{ url_for('edit_equipment_item', item_id=e.id) }}" class="inline-form" style="display:flex; gap:8px; flex-wrap:wrap; align-items:flex-end;">
+                            <label style="font-size:11px; flex:1;">Item<br><input type="text" name="item_name" value="{{ e.item_name }}" style="width:100%;"></label>
+                            <label style="font-size:11px;">Category<br><input type="text" name="eq_category" value="{{ e.category }}"></label>
+                            <label style="font-size:11px;">Part #<br><input type="text" name="part_number" value="{{ e.part_number }}" style="width:120px;"></label>
+                            <label style="font-size:11px;">Manufacturer<br><input type="text" name="manufacturer" value="{{ e.manufacturer }}" style="width:140px;"></label>
+                            <label style="font-size:11px;">Unit $<br><input type="number" step="0.01" min="0" name="unit_cost" value="{{ e.unit_cost }}" style="width:110px;"></label>
+                            <label style="font-size:11px;">Unit<br><input type="text" name="unit" value="{{ e.unit }}" style="width:80px;"></label>
+                            <button type="submit" class="btn btn-small btn-primary">Save</button>
                         </form>
                     </td>
                 </tr>
@@ -491,9 +518,21 @@
                     <td>${{ "%.2f"|format(t.rate) }}</td>
                     <td>{{ t.unit }}</td>
                     <td class="td-desc">{{ t.description or '—' }}</td>
-                    <td>
+                    <td style="white-space:nowrap;">
+                        <button type="button" class="btn btn-small btn-secondary row-edit-btn" data-target="edit-tr-{{ t.id }}">Edit</button>
                         <form method="post" action="{{ url_for('delete_travel_rate', rate_id=t.id) }}" class="inline-form">
                             <button type="submit" class="btn btn-small btn-danger" onclick="return confirm('Delete this rate?')">Delete</button>
+                        </form>
+                    </td>
+                </tr>
+                <tr id="edit-tr-{{ t.id }}" class="inline-edit-row" style="display:none;">
+                    <td colspan="5">
+                        <form method="post" action="{{ url_for('edit_travel_rate', rate_id=t.id) }}" class="inline-form" style="display:flex; gap:8px; flex-wrap:wrap; align-items:flex-end;">
+                            <label style="font-size:11px;">Expense<br><input type="text" name="expense_type" value="{{ t.expense_type }}"></label>
+                            <label style="font-size:11px;">Rate $<br><input type="number" step="0.01" min="0" name="travel_rate" value="{{ t.rate }}" style="width:110px;"></label>
+                            <label style="font-size:11px;">Unit<br><input type="text" name="travel_unit" value="{{ t.unit }}" style="width:110px;"></label>
+                            <label style="font-size:11px; flex:1;">Description<br><input type="text" name="travel_description" value="{{ t.description }}" style="width:100%;"></label>
+                            <button type="submit" class="btn btn-small btn-primary">Save</button>
                         </form>
                     </td>
                 </tr>
@@ -693,6 +732,14 @@
         btn.addEventListener("click", function(){
             var target = document.getElementById(btn.dataset.target);
             if (target) target.open = true;
+        });
+    });
+
+    // Inline row editing for rate tables
+    document.querySelectorAll(".row-edit-btn").forEach(function(btn){
+        btn.addEventListener("click", function(){
+            var row = document.getElementById(btn.dataset.target);
+            if (row) row.style.display = row.style.display === "none" ? "" : "none";
         });
     });
 

--- a/web_templates/posture.html
+++ b/web_templates/posture.html
@@ -26,7 +26,7 @@
 <div class="posture-summary">
     <div class="posture-summary-check">&#10003;</div>
     <div>
-        <div class="posture-summary-title">{{ current_user.company_name or 'Your' }} Posture</div>
+        <div class="posture-summary-title">{{ (org.name if org else '') or 'Your' }} Posture</div>
         <div class="posture-summary-meta">
             {{ total_items }} item(s) configured
             {% if last_updated %} &middot; Updated {{ last_updated.strftime('%b %d, %Y %H:%M') }}{% endif %}
@@ -511,26 +511,27 @@
         <summary class="accordion-head">
             Branding &amp; Logo
             <span class="accordion-head-chips">
-                <span class="count-chip {{ 'count-zero' if not current_user.company_logo_path }}">{{ 'Logo set' if current_user.company_logo_path else 'No logo' }}</span>
+                <span class="count-chip {{ 'count-zero' if not (org and org.logo_path) }}">{{ 'Logo set' if org and org.logo_path else 'No logo' }}</span>
                 <span class="acc-chevron">&#9654;</span>
             </span>
         </summary>
         <div class="accordion-body">
             <p class="card-desc" style="margin-top:12px;">
                 Upload your company logo to automatically brand your generated proposals.
+                The logo is <strong>workspace-wide</strong> — every member's proposals carry the same identity.
                 Accepted formats: <strong>PNG, JPG, JPEG, WebP, GIF, BMP</strong>.
                 Uploaded images are automatically resized and re-encoded as optimized PNG
                 (longest side up to {{ logo_max_dimension }}px) so they stay small in memory
                 and look crisp in Word documents.
             </p>
 
-            {% if current_user.company_logo_path %}
+            {% if org and org.logo_path %}
             <div class="logo-preview-wrap">
                 <div class="logo-preview-box">
-                    <img src="{{ url_for('company_logo_preview') }}?v={{ current_user.id[:6] }}{{ current_user.company_logo_original_name }}" alt="Company logo preview" class="logo-preview-img">
+                    <img src="{{ url_for('company_logo_preview') }}?v={{ org.id[:6] }}{{ org.logo_original_name }}" alt="Company logo preview" class="logo-preview-img">
                 </div>
                 <div class="logo-preview-meta">
-                    <div class="logo-preview-name">{{ current_user.company_logo_original_name or 'logo.png' }}</div>
+                    <div class="logo-preview-name">{{ org.logo_original_name or 'logo.png' }}</div>
                     <form method="post" action="{{ url_for('delete_company_logo') }}" class="inline-form" onsubmit="return confirm('Remove your company logo?');">
                         <button type="submit" class="btn btn-small btn-danger">Remove logo</button>
                     </form>
@@ -543,17 +544,17 @@
             <form method="post" action="{{ url_for('upload_company_logo') }}" enctype="multipart/form-data" class="upload-inline">
                 <div class="form-group">
                     <label for="company_logo">
-                        {% if current_user.company_logo_path %}Replace logo{% else %}Upload logo{% endif %}
+                        {% if org and org.logo_path %}Replace logo{% else %}Upload logo{% endif %}
                     </label>
                     <input type="file" id="company_logo" name="company_logo" accept=".png,.jpg,.jpeg,.webp,.gif,.bmp,image/*" required>
                     <span class="form-hint">Most common image types accepted. Images are automatically compressed.</span>
                 </div>
                 <button type="submit" class="btn btn-secondary">
-                    {% if current_user.company_logo_path %}Replace Logo{% else %}Upload Logo{% endif %}
+                    {% if org and org.logo_path %}Replace Logo{% else %}Upload Logo{% endif %}
                 </button>
             </form>
 
-            {% if current_user.company_logo_path %}
+            {% if org and org.logo_path %}
             <hr class="card-divider">
             <form method="post" action="{{ url_for('settings') }}">
                 <h3 class="subheading">Proposal Branding Options</h3>
@@ -562,7 +563,7 @@
                 <div class="form-group checkbox-group">
                     <label class="checkbox-label">
                         <input type="checkbox" name="company_logo_use_in_proposals" value="1"
-                               {% if current_user.company_logo_use_in_proposals %}checked{% endif %}>
+                               {% if org.logo_use_in_proposals %}checked{% endif %}>
                         <span>Use this logo on all newly generated proposals</span>
                     </label>
                 </div>
@@ -570,15 +571,15 @@
                 <div class="form-group">
                     <label>Logo Placement</label>
                     <div class="radio-group">
-                        <label class="radio-card {% if (current_user.company_logo_placement or 'top_left') == 'top_left' %}selected{% endif %}">
+                        <label class="radio-card {% if (org.logo_placement or 'top_left') == 'top_left' %}selected{% endif %}">
                             <input type="radio" name="company_logo_placement" value="top_left"
-                                   {% if (current_user.company_logo_placement or 'top_left') == 'top_left' %}checked{% endif %}>
+                                   {% if (org.logo_placement or 'top_left') == 'top_left' %}checked{% endif %}>
                             <span class="radio-card-title">Top Left</span>
                             <span class="radio-card-desc">Left-aligned header on the title page. Classic letterhead look.</span>
                         </label>
-                        <label class="radio-card {% if current_user.company_logo_placement == 'center' %}selected{% endif %}">
+                        <label class="radio-card {% if org.logo_placement == 'center' %}selected{% endif %}">
                             <input type="radio" name="company_logo_placement" value="center"
-                                   {% if current_user.company_logo_placement == 'center' %}checked{% endif %}>
+                                   {% if org.logo_placement == 'center' %}checked{% endif %}>
                             <span class="radio-card-title">Centered</span>
                             <span class="radio-card-desc">Centered above the proposal title (cover-page style).</span>
                         </label>
@@ -588,7 +589,7 @@
                 <div class="form-group checkbox-group">
                     <label class="checkbox-label">
                         <input type="checkbox" name="company_logo_show_on_cover" value="1"
-                               {% if current_user.company_logo_show_on_cover %}checked{% endif %}>
+                               {% if org.logo_show_on_cover %}checked{% endif %}>
                         <span>Add a dedicated cover page with the logo before the proposal body</span>
                     </label>
                     <span class="form-hint">Recommended for formal RFP responses. Uncheck to embed inline at the top of page 1 only.</span>
@@ -597,9 +598,7 @@
                 <!-- Preserve other profile fields so this form save doesn't wipe them -->
                 <input type="hidden" name="display_name" value="{{ current_user.display_name }}">
                 <input type="hidden" name="email" value="{{ current_user.email }}">
-                <input type="hidden" name="company_name" value="{{ current_user.company_name }}">
                 <input type="hidden" name="font_preference" value="{{ current_user.font_preference }}">
-                <input type="hidden" name="llm_provider" value="{{ current_user.llm_provider }}">
                 <input type="hidden" name="llm_model" value="{{ current_user.llm_model }}">
                 <input type="hidden" name="from_posture" value="1">
 

--- a/web_templates/posture.html
+++ b/web_templates/posture.html
@@ -29,7 +29,7 @@
         <div class="posture-summary-title">{{ (org.name if org else '') or 'Your' }} Posture</div>
         <div class="posture-summary-meta">
             {{ total_items }} item(s) configured
-            {% if last_updated %} &middot; Updated {{ last_updated.strftime('%b %d, %Y %H:%M') }}{% endif %}
+            {% if last_updated %} &middot; Updated {{ last_updated | localtime('full') }}{% endif %}
             &middot; Maintained by {{ current_user.display_name or current_user.username }}
         </div>
     </div>

--- a/web_templates/project_scope.html
+++ b/web_templates/project_scope.html
@@ -19,7 +19,7 @@
             <h1>Scope of Work</h1>
             <p class="page-subtitle">
                 {{ project.name }} &middot; {{ scope.vertical_label }}
-                &middot; AI drafted {{ scope.generated_at.strftime('%b %d, %Y %H:%M') }}
+                &middot; AI drafted {{ scope.generated_at | localtime('full') }}
             </p>
         </div>
         <div class="header-actions">
@@ -38,7 +38,7 @@
 {% if scope.status == 'approved' %}
 <div class="scope-approved-banner">
     <span>&#10003;</span>
-    <span>Scope approved{% if scope.approved_at %} on {{ scope.approved_at.strftime('%b %d, %Y %H:%M') }}{% endif %}
+    <span>Scope approved{% if scope.approved_at %} on {{ scope.approved_at | localtime('full') }}{% endif %}
         — the AI will draft the proposal against exactly these {{ included_count }} item(s).</span>
     <form method="post" action="{{ url_for('reopen_scope', project_id=project.id) }}" class="inline-form" style="margin-left:auto;">
         <button type="submit" class="btn btn-small btn-secondary">Reopen for edits</button>

--- a/web_templates/project_scope.html
+++ b/web_templates/project_scope.html
@@ -24,7 +24,7 @@
         </div>
         <div class="header-actions">
             <form method="post" action="{{ url_for('generate_scope', project_id=project.id) }}" class="inline-form"
-                  onsubmit="return confirm('Re-draft the scope with AI? Your current items (including edits) will be replaced.');">
+                  onsubmit="return confirm('Re-draft the scope with AI? AI-proposed items will be replaced; items your team added are kept.');">
                 <input type="hidden" name="vertical" value="auto">
                 <button type="submit" class="btn btn-secondary">&#10227; Re-draft with AI</button>
             </form>
@@ -86,6 +86,13 @@
                             <span class="chip chip-red">Removed from scope</span>
                             {% endif %}
                         </div>
+                        <details class="scope-item-edit" style="margin-top:6px;">
+                            <summary style="cursor:pointer; font-size:12.5px; color:var(--sea-600);">&#9998; Edit wording</summary>
+                            <form method="post" action="{{ url_for('edit_scope_item', project_id=project.id, item_id=item.id) }}" style="margin-top:6px;">
+                                <textarea name="item_text" rows="2" required style="width:100%; font-size:13px;">{{ item.item_text }}</textarea>
+                                <button type="submit" class="btn btn-small btn-secondary" style="margin-top:4px;">Save wording</button>
+                            </form>
+                        </details>
                     </div>
                     {% if item.source == 'human' %}
                     <form method="post" action="{{ url_for('delete_scope_item', project_id=project.id, item_id=item.id) }}" class="inline-form" onsubmit="return confirm('Delete this scope item?');">

--- a/web_templates/project_scope.html
+++ b/web_templates/project_scope.html
@@ -61,6 +61,11 @@
 </div>
 {% endif %}
 
+<!-- One batch form collects every include/strike checkbox (via the HTML
+     form= attribute) so reviewing 25 items is one save, not 25 page loads. -->
+<form id="scope-batch-form" method="post"
+      action="{{ url_for('batch_update_scope', project_id=project.id) }}"></form>
+
 <div class="workspace-grid">
     <div class="workspace-main">
         <div class="card">
@@ -68,11 +73,12 @@
             <ul class="scope-list" style="margin-top: 12px;">
                 {% for item in items %}
                 <li class="scope-item{% if item.status == 'removed' %} scope-removed{% endif %}{% if item.source == 'human' %} scope-added{% endif %}">
-                    <form method="post" action="{{ url_for('toggle_scope_item', project_id=project.id, item_id=item.id) }}" class="scope-item-toggle">
-                        <input type="checkbox" {{ 'checked' if item.status == 'included' }}
-                               onchange="this.form.submit()"
+                    <span class="scope-item-toggle">
+                        <input type="checkbox" form="scope-batch-form" name="included" value="{{ item.id }}"
+                               class="scope-batch-check" {{ 'checked' if item.status == 'included' }}
+                               aria-label="Include in scope"
                                title="{{ 'Remove from scope' if item.status == 'included' else 'Include in scope' }}">
-                    </form>
+                    </span>
                     <div class="scope-item-main">
                         <div class="scope-item-text">{{ item.item_text }}</div>
                         <div class="scope-item-meta">
@@ -133,7 +139,7 @@
     <aside class="rail">
         <div class="rail-card">
             <h3>{{ 'Scope Approved' if scope.status == 'approved' else 'Approve This Scope' }}</h3>
-            <p style="font-size: 13px; color: var(--ink-500); margin-bottom: 12px;">
+            <p style="font-size: 13px; color: var(--ink-500); margin-bottom: 8px;">
                 {% if scope.status == 'approved' %}
                 Next: generate the proposal from the project page. The draft will follow this scope exactly.
                 {% else %}
@@ -141,7 +147,13 @@
                 Removed items stay visible here for the record.
                 {% endif %}
             </p>
+            <p style="font-size: 12.5px; color: var(--ink-500); margin-bottom: 12px;">
+                <span class="chip chip-ok">{{ ai_kept }} AI kept</span>
+                <span class="chip chip-red">{{ ai_struck }} struck</span>
+                <span class="chip chip-sea">{{ human_added }} team-added</span>
+            </p>
             <div class="rail-actions">
+                <button type="submit" form="scope-batch-form" class="btn btn-secondary" id="scope-save-btn">Save item changes</button>
                 {% if scope.status != 'approved' %}
                 <form method="post" action="{{ url_for('approve_scope', project_id=project.id) }}" class="inline-form">
                     <button type="submit" class="btn btn-primary">&#10003; Approve Scope ({{ included_count }})</button>
@@ -150,6 +162,7 @@
                 <a href="{{ url_for('project_upload', project_id=project.id) }}" class="btn btn-primary">Continue to Generate &rarr;</a>
                 {% endif %}
             </div>
+            <p class="form-hint" id="scope-dirty-hint" style="display:none; margin-top:6px;">&#9888; Unsaved checkbox changes — save before approving.</p>
         </div>
 
         <div class="rail-card">
@@ -163,4 +176,22 @@
         </div>
     </aside>
 </div>
+{% endblock %}
+
+{% block scripts %}
+<script>
+(function(){
+    var saveBtn = document.getElementById("scope-save-btn");
+    var hint = document.getElementById("scope-dirty-hint");
+    if (!saveBtn) return;
+    document.querySelectorAll(".scope-batch-check").forEach(function(cb){
+        cb.addEventListener("change", function(){
+            saveBtn.classList.remove("btn-secondary");
+            saveBtn.classList.add("btn-primary");
+            saveBtn.textContent = "Save item changes •";
+            if (hint) hint.style.display = "block";
+        });
+    });
+})();
+</script>
 {% endblock %}

--- a/web_templates/project_upload.html
+++ b/web_templates/project_upload.html
@@ -119,6 +119,7 @@
                     <td><span class="badge badge-doc-{{ d.file_type }}">{{ d.file_type }}</span></td>
                     <td>
                         {% if d.text_chars is none %}<span class="form-hint">&mdash;</span>
+                        {% elif d.text_chars == 0 and d.original_filename.lower().endswith('.pdf') and ocr_enabled %}<span class="chip chip-gold" title="No embedded text, but it will be read with OCR when you generate.">&#128444; Scanned &middot; OCR</span>
                         {% elif d.text_chars == 0 %}<span class="chip chip-red" title="No machine-readable text — likely a scanned image. The AI cannot analyze this file.">&#9888; No text</span>
                         {% else %}<span class="chip chip-ok" title="{{ '{:,}'.format(d.text_chars) }} characters extracted">&#10003; {{ '{:,}'.format(d.text_chars) }} chars</span>
                         {% endif %}

--- a/web_templates/project_upload.html
+++ b/web_templates/project_upload.html
@@ -270,6 +270,14 @@
                 </div>
 
                 <button type="submit" class="btn btn-primary btn-large" id="generate-btn">Generate Proposal</button>
+                <p class="form-hint" style="margin-top:8px;">
+                    Takes ~1&ndash;3 minutes and uses 1 AI generation
+                    {% if gen_limit is defined and gen_limit >= 0 %}
+                    &mdash; <strong>{{ gens_used }} of {{ gen_limit }}</strong> used this month{% if gen_limit - gens_used <= 2 %} <a href="{{ url_for('billing_page') }}">(upgrade for more)</a>{% endif %}.
+                    {% else %}
+                    (your plan has unlimited generations).
+                    {% endif %}
+                </p>
             </form>
 
             <div class="processing-overlay" id="processing" style="display:none;">

--- a/web_templates/project_upload.html
+++ b/web_templates/project_upload.html
@@ -111,14 +111,25 @@
         <div class="card">
             <h2>Project Documents ({{ documents | length }})</h2>
             <table class="mini-table">
-                <thead><tr><th>File</th><th>Type</th><th>Size</th><th>Uploaded</th></tr></thead>
+                <thead><tr><th>File</th><th>Type</th><th>AI-readable</th><th>Size</th><th>Uploaded</th><th></th></tr></thead>
                 <tbody>
                 {% for d in documents %}
                 <tr>
                     <td>{{ d.original_filename }}</td>
                     <td><span class="badge badge-doc-{{ d.file_type }}">{{ d.file_type }}</span></td>
+                    <td>
+                        {% if d.text_chars is none %}<span class="form-hint">&mdash;</span>
+                        {% elif d.text_chars == 0 %}<span class="chip chip-red" title="No machine-readable text — likely a scanned image. The AI cannot analyze this file.">&#9888; No text</span>
+                        {% else %}<span class="chip chip-ok" title="{{ '{:,}'.format(d.text_chars) }} characters extracted">&#10003; {{ '{:,}'.format(d.text_chars) }} chars</span>
+                        {% endif %}
+                    </td>
                     <td>{% if d.file_size >= 1048576 %}{{ "%.1f"|format(d.file_size / 1048576) }} MB{% elif d.file_size >= 1024 %}{{ "%.0f"|format(d.file_size / 1024) }} KB{% else %}{{ d.file_size }} B{% endif %}</td>
                     <td>{{ d.uploaded_at.strftime('%Y-%m-%d %H:%M') }}</td>
+                    <td>
+                        <form method="post" action="{{ url_for('delete_document', doc_id=d.id) }}" class="inline-form" onsubmit="return confirm('Delete {{ d.original_filename }}? This cannot be undone.');">
+                            <button type="submit" class="btn btn-small btn-danger">Delete</button>
+                        </form>
+                    </td>
                 </tr>
                 {% endfor %}
                 </tbody>
@@ -166,6 +177,14 @@
             <h2>Draft Proposal with AI</h2>
             {% if scope and scope.status == 'approved' %}
             <p class="card-desc">Using your approved Scope of Work ({{ scope_included }} item(s)).</p>
+            {% elif scope and scope.status == 'draft' %}
+            <div class="posture-callout" style="border-left: 3px solid var(--gold); background: var(--gold-bg); margin-bottom: 12px;">
+                <span>&#9888;</span>
+                <div>
+                    <strong>Your drafted scope is NOT approved yet — this draft will ignore it.</strong>
+                    <a href="{{ url_for('project_scope', project_id=project.id) }}">Review &amp; approve the scope</a> first if the proposal should follow it.
+                </div>
+            </div>
             {% endif %}
             <form method="post" action="{{ url_for('project_generate', project_id=project.id) }}" id="generate-form">
 
@@ -357,6 +376,23 @@
             </form>
             {% endif %}
         </div>
+
+        {% if project.user_id == current_user.id or current_user.is_admin %}
+        <div class="rail-card" style="border: 1px solid var(--red-line);">
+            <h3 style="color: var(--red);">Danger Zone</h3>
+            <p style="font-size: 12.5px; color: var(--ink-500); margin-bottom: 10px;">
+                Permanently delete this project, its documents, proposals, and files. This cannot be undone.
+            </p>
+            <form method="post" action="{{ url_for('delete_project', project_id=project.id) }}"
+                  onsubmit="return confirm('Permanently delete “{{ project.name }}” and ALL its data? This cannot be undone.');">
+                <div class="form-group">
+                    <label style="font-size: 12px;">Type the project name to confirm</label>
+                    <input type="text" name="confirm_name" placeholder="{{ project.name }}" required>
+                </div>
+                <button type="submit" class="btn btn-small btn-danger" style="width:100%;">Delete project</button>
+            </form>
+        </div>
+        {% endif %}
 
         <div class="rail-card">
             <h3>At a Glance</h3>

--- a/web_templates/project_upload.html
+++ b/web_templates/project_upload.html
@@ -124,7 +124,7 @@
                         {% endif %}
                     </td>
                     <td>{% if d.file_size >= 1048576 %}{{ "%.1f"|format(d.file_size / 1048576) }} MB{% elif d.file_size >= 1024 %}{{ "%.0f"|format(d.file_size / 1024) }} KB{% else %}{{ d.file_size }} B{% endif %}</td>
-                    <td>{{ d.uploaded_at.strftime('%Y-%m-%d %H:%M') }}</td>
+                    <td>{{ d.uploaded_at | localtime('full') }}</td>
                     <td>
                         <form method="post" action="{{ url_for('delete_document', doc_id=d.id) }}" class="inline-form" onsubmit="return confirm('Delete {{ d.original_filename }}? This cannot be undone.');">
                             <button type="submit" class="btn btn-small btn-danger">Delete</button>
@@ -310,7 +310,7 @@
                 <tbody>
                 {% for prop in proposals %}
                 <tr>
-                    <td>{{ prop.generated_at.strftime('%Y-%m-%d %H:%M') if prop.generated_at else 'N/A' }}</td>
+                    <td>{% if prop.generated_at %}{{ prop.generated_at | localtime('full') }}{% else %}N/A{% endif %}</td>
                     <td><span class="badge badge-{{ prop.document_type | lower }}">{{ prop.document_type }}</span></td>
                     <td><span class="badge badge-vertical">{{ prop.vertical_label }}</span></td>
                     <td>
@@ -399,7 +399,7 @@
             <ul class="timeline">
                 <li>
                     <span class="tl-title">{{ documents | length }} document(s) uploaded</span>
-                    <div class="tl-meta">{{ 'Latest: ' + documents[0].uploaded_at.strftime('%b %d, %H:%M') if documents else 'Upload an RFP/RFQ to begin' }}</div>
+                    <div class="tl-meta">{% if documents %}Latest: {{ documents[0].uploaded_at | localtime }}{% else %}Upload an RFP/RFQ to begin{% endif %}</div>
                 </li>
                 <li>
                     <span class="tl-title">{{ open_clarifications }} open clarification(s)</span>

--- a/web_templates/proposal.html
+++ b/web_templates/proposal.html
@@ -221,6 +221,12 @@
                     {% endif %}
                     {% if proposal.review_status == 'internally_approved' %}
                     <form method="post" action="{{ url_for('submit_to_customer', proposal_id=proposal.id) }}" class="inline-form">
+                        {% if proposal.action_items_count %}
+                        <label class="check-inline" style="display:block; margin-bottom:6px;">
+                            <input type="checkbox" name="ack_action_items" value="1">
+                            Send despite <strong>{{ proposal.action_items_count }}</strong> open <a href="#action-items">action item(s)</a>
+                        </label>
+                        {% endif %}
                         <button type="submit" class="btn btn-primary">Submit to Customer</button>
                     </form>
                     <button type="button" class="btn btn-secondary" id="run-preflight">Run Pre-flight Check</button>
@@ -258,13 +264,16 @@
                 <li><strong>{{ share.view_count or 0 }}</strong> view(s){% if share.last_viewed_at %} · last {{ share.last_viewed_at | localtime }}{% endif %}</li>
                 {% if share.version_number %}<li>Customer sees <strong>v{{ share.version_number }}</strong>{% if versions and share.version_number < versions[0].version_number %} · you're on v{{ versions[0].version_number }}{% endif %}</li>{% endif %}
                 {% if share.expires_at %}<li>Link expires {{ share.expires_at.strftime('%b %d, %Y') }}</li>{% endif %}
-                {% if share.decision %}<li>Customer <strong>{{ share.decision }}</strong>{{ ' on ' + share.decided_at.strftime('%b %d') if share.decided_at }}</li>{% endif %}
+                {% if share.decision %}<li>Customer <strong>{{ share.decision }}</strong>{% if share.decided_by_name %} — signed by {{ share.decided_by_name }}{% if share.decided_by_title %} ({{ share.decided_by_title }}){% endif %}{% endif %}{{ ' on ' + share.decided_at.strftime('%b %d') if share.decided_at }}</li>{% endif %}
             </ul>
             {% if versions and share.version_number and share.version_number < versions[0].version_number and not share.decision %}
             <form method="post" action="{{ url_for('create_share', proposal_id=proposal.id) }}" class="inline-form" style="margin-bottom:8px;">
                 <input type="hidden" name="customer_email" value="{{ share.customer_email or '' }}">
                 <input type="hidden" name="allow_comments" value="{{ '1' if share.allow_comments else '0' }}">
                 <input type="hidden" name="allow_decision" value="{{ '1' if share.allow_decision else '0' }}">
+                {% if proposal.action_items_count %}
+                <label class="check-inline" style="display:block; margin-bottom:4px;"><input type="checkbox" name="ack_action_items" value="1"> Update despite {{ proposal.action_items_count }} open action item(s)</label>
+                {% endif %}
                 <button type="submit" class="btn btn-small btn-primary">Update customer view to v{{ versions[0].version_number }}</button>
             </form>
             {% endif %}
@@ -278,6 +287,9 @@
                 <label class="check-inline"><input type="checkbox" name="allow_comments" value="1" checked> Allow comments</label>
                 <label class="check-inline"><input type="checkbox" name="allow_decision" value="1" checked> Allow accept/decline</label>
                 <label class="check-inline"><input type="checkbox" name="send_email" value="1"> Email it with PDF attached</label>
+                {% if proposal.action_items_count %}
+                <label class="check-inline"><input type="checkbox" name="ack_action_items" value="1"> Share despite <strong>{{ proposal.action_items_count }}</strong> open action item(s)</label>
+                {% endif %}
                 <button type="submit" class="btn btn-primary" style="margin-top:8px; width:100%;">Create share link</button>
             </form>
             {% endif %}

--- a/web_templates/proposal.html
+++ b/web_templates/proposal.html
@@ -256,8 +256,17 @@
             </div>
             <ul class="share-stats">
                 <li><strong>{{ share.view_count or 0 }}</strong> view(s){% if share.last_viewed_at %} · last {{ share.last_viewed_at.strftime('%b %d, %H:%M') }}{% endif %}</li>
+                {% if share.version_number %}<li>Customer sees <strong>v{{ share.version_number }}</strong>{% if versions and share.version_number < versions[0].version_number %} · you're on v{{ versions[0].version_number }}{% endif %}</li>{% endif %}
                 {% if share.decision %}<li>Customer <strong>{{ share.decision }}</strong>{{ ' on ' + share.decided_at.strftime('%b %d') if share.decided_at }}</li>{% endif %}
             </ul>
+            {% if versions and share.version_number and share.version_number < versions[0].version_number and not share.decision %}
+            <form method="post" action="{{ url_for('create_share', proposal_id=proposal.id) }}" class="inline-form" style="margin-bottom:8px;">
+                <input type="hidden" name="customer_email" value="{{ share.customer_email or '' }}">
+                <input type="hidden" name="allow_comments" value="{{ '1' if share.allow_comments else '0' }}">
+                <input type="hidden" name="allow_decision" value="{{ '1' if share.allow_decision else '0' }}">
+                <button type="submit" class="btn btn-small btn-primary">Update customer view to v{{ versions[0].version_number }}</button>
+            </form>
+            {% endif %}
             <form method="post" action="{{ url_for('revoke_share', proposal_id=proposal.id) }}" class="inline-form">
                 <button type="submit" class="btn btn-small btn-secondary">Revoke link</button>
             </form>

--- a/web_templates/proposal.html
+++ b/web_templates/proposal.html
@@ -77,10 +77,10 @@
                         {% endfor %}
                     </select>
                     {% endif %}
-                    <div class="viewer-zoom" title="Text size">
-                        <button type="button" id="font-minus">&minus;</button>
-                        <span class="vz-label" id="font-label">100%</span>
-                        <button type="button" id="font-plus">+</button>
+                    <div class="viewer-zoom" role="group" aria-label="Text size" title="Text size">
+                        <button type="button" id="font-minus" aria-label="Decrease text size">&minus;</button>
+                        <span class="vz-label" id="font-label" aria-live="polite">100%</span>
+                        <button type="button" id="font-plus" aria-label="Increase text size">+</button>
                     </div>
                     <div class="viewer-seg">
                         <a href="{{ url_for('view_proposal', proposal_id=proposal.id) }}" class="{{ 'active' if view_mode == 'clean' }}">Clean</a>
@@ -150,7 +150,7 @@
                 <li id="comment-{{ c.id }}" class="comment-item{% if c.is_resolved %} comment-resolved{% endif %}">
                     <div class="comment-meta">
                         <strong>{{ c.author.display_name or c.author.username if c.author else 'User' }}</strong>
-                        <span class="comment-time">{{ c.created_at.strftime('%Y-%m-%d %H:%M') }}</span>
+                        <span class="comment-time">{{ c.created_at | localtime('full') }}</span>
                         {% if c.section_anchor %}
                         <span class="comment-anchor">&rsaquo; {{ c.section_anchor }}</span>
                         {% endif %}
@@ -186,7 +186,7 @@
         <div class="rail-card rail-card-terminal">
             <h3>&#127942; Awarded</h3>
             <p style="font-size:13px; color:var(--ink-700);">Customer accepted the proposal — project won.
-            Completed {{ status_history[0].created_at.strftime('%b %d, %Y %H:%M') if status_history else '' }}.</p>
+            Completed {% if status_history %}{{ status_history[0].created_at | localtime('full') }}{% endif %}.</p>
         </div>
         {% elif proposal.review_status in ('lost', 'customer_declined') %}
         <div class="rail-card rail-card-terminal rail-lost">
@@ -255,7 +255,7 @@
                 <button type="button" class="btn btn-small btn-secondary" onclick="navigator.clipboard.writeText(document.getElementById('share-url-input').value)">Copy</button>
             </div>
             <ul class="share-stats">
-                <li><strong>{{ share.view_count or 0 }}</strong> view(s){% if share.last_viewed_at %} · last {{ share.last_viewed_at.strftime('%b %d, %H:%M') }}{% endif %}</li>
+                <li><strong>{{ share.view_count or 0 }}</strong> view(s){% if share.last_viewed_at %} · last {{ share.last_viewed_at | localtime }}{% endif %}</li>
                 {% if share.version_number %}<li>Customer sees <strong>v{{ share.version_number }}</strong>{% if versions and share.version_number < versions[0].version_number %} · you're on v{{ versions[0].version_number }}{% endif %}</li>{% endif %}
                 {% if share.expires_at %}<li>Link expires {{ share.expires_at.strftime('%b %d, %Y') }}</li>{% endif %}
                 {% if share.decision %}<li>Customer <strong>{{ share.decision }}</strong>{{ ' on ' + share.decided_at.strftime('%b %d') if share.decided_at }}</li>{% endif %}
@@ -313,7 +313,7 @@
                 {% for h in status_history %}
                 <li>
                     <span class="tl-title">{{ lifecycle_labels.get(h.to_status, h.to_status) }}</span>
-                    <div class="tl-meta">by {{ h.actor.display_name if h.actor else 'system' }} · {{ h.created_at.strftime('%b %d, %H:%M') }}</div>
+                    <div class="tl-meta">by {{ h.actor.display_name if h.actor else 'system' }} · {{ h.created_at | localtime }}</div>
                     {% if h.note %}<div class="tl-note">{{ h.note }}</div>{% endif %}
                 </li>
                 {% endfor %}

--- a/web_templates/proposal.html
+++ b/web_templates/proposal.html
@@ -257,6 +257,7 @@
             <ul class="share-stats">
                 <li><strong>{{ share.view_count or 0 }}</strong> view(s){% if share.last_viewed_at %} · last {{ share.last_viewed_at.strftime('%b %d, %H:%M') }}{% endif %}</li>
                 {% if share.version_number %}<li>Customer sees <strong>v{{ share.version_number }}</strong>{% if versions and share.version_number < versions[0].version_number %} · you're on v{{ versions[0].version_number }}{% endif %}</li>{% endif %}
+                {% if share.expires_at %}<li>Link expires {{ share.expires_at.strftime('%b %d, %Y') }}</li>{% endif %}
                 {% if share.decision %}<li>Customer <strong>{{ share.decision }}</strong>{{ ' on ' + share.decided_at.strftime('%b %d') if share.decided_at }}</li>{% endif %}
             </ul>
             {% if versions and share.version_number and share.version_number < versions[0].version_number and not share.decision %}

--- a/web_templates/proposal_edit.html
+++ b/web_templates/proposal_edit.html
@@ -43,6 +43,14 @@
                 </div>
             </div>
 
+            <input type="hidden" name="base_version" value="{{ base_version }}">
+
+            <div id="draft-restore-bar" style="display:none; padding:8px 12px; margin-bottom:8px; background: var(--gold-bg); border: 1px solid var(--gold-line); border-radius: 8px; font-size: 13px; align-items:center; gap:10px;">
+                <span>&#128190; An unsaved local draft from <strong id="draft-restore-when"></strong> was found.</span>
+                <button type="button" class="btn btn-small btn-primary" id="draft-restore-btn">Restore draft</button>
+                <button type="button" class="btn btn-small btn-secondary" id="draft-discard-btn">Discard</button>
+            </div>
+
             <div id="editor-container">
                 <textarea name="markdown_content" id="markdown-editor" spellcheck="true">{{ current_content }}</textarea>
             </div>
@@ -74,7 +82,7 @@
                     </span>
                 </div>
                 <p class="version-summary">{{ v.change_summary or 'No description' }}</p>
-                <p class="version-date">{{ v.created_at.strftime('%Y-%m-%d %H:%M') }}</p>
+                <p class="version-date">{{ v.created_at | localtime('full') }}</p>
                 {% if v.editor %}
                 <p class="version-editor">by {{ v.editor.display_name or v.editor.username }}</p>
                 {% endif %}
@@ -144,8 +152,29 @@
     editor.addEventListener("input", autoResize);
     autoResize();
 
-    // Track unsaved changes
+    // Track unsaved changes + autosave a local draft so navigation, crashes,
+    // or session expiry never lose work.
     var originalContent = editor.value;
+    var draftKey = "pm-editor-draft-{{ proposal.id }}";
+    var draftTimer = null;
+
+    function saveDraft() {
+        if (!window.localStorage) return;
+        try {
+            if (editor.value === originalContent) {
+                localStorage.removeItem(draftKey);
+                return;
+            }
+            localStorage.setItem(draftKey, JSON.stringify({
+                content: editor.value,
+                savedAt: new Date().toISOString()
+            }));
+            var t = new Date().toLocaleTimeString(undefined, {hour: "2-digit", minute: "2-digit"});
+            status.textContent = "Unsaved changes — draft kept locally at " + t;
+            status.style.color = "#d97706";
+        } catch (e) { /* storage full/unavailable — degrade silently */ }
+    }
+
     editor.addEventListener("input", function() {
         if (editor.value !== originalContent) {
             status.textContent = "Unsaved changes";
@@ -154,11 +183,42 @@
             status.textContent = "Ready";
             status.style.color = "";
         }
+        clearTimeout(draftTimer);
+        draftTimer = setTimeout(saveDraft, 800);
     });
+
+    // Offer to restore a leftover draft (only when it differs from the server copy)
+    (function(){
+        if (!window.localStorage) return;
+        var raw = null;
+        try { raw = localStorage.getItem(draftKey); } catch (e) { return; }
+        if (!raw) return;
+        var draft;
+        try { draft = JSON.parse(raw); } catch (e) { localStorage.removeItem(draftKey); return; }
+        if (!draft || !draft.content || draft.content === editor.value) {
+            localStorage.removeItem(draftKey);
+            return;
+        }
+        var bar = document.getElementById("draft-restore-bar");
+        var when = document.getElementById("draft-restore-when");
+        when.textContent = draft.savedAt ? new Date(draft.savedAt).toLocaleString() : "earlier";
+        bar.style.display = "flex";
+        document.getElementById("draft-restore-btn").addEventListener("click", function(){
+            editor.value = draft.content;
+            editor.dispatchEvent(new Event("input"));
+            bar.style.display = "none";
+        });
+        document.getElementById("draft-discard-btn").addEventListener("click", function(){
+            try { localStorage.removeItem(draftKey); } catch (e) {}
+            bar.style.display = "none";
+        });
+    })();
 
     form.addEventListener("submit", function() {
         status.textContent = "Saving...";
         originalContent = editor.value;
+        clearTimeout(draftTimer);
+        try { if (window.localStorage) localStorage.removeItem(draftKey); } catch (e) {}
     });
 
     // Preview toggle

--- a/web_templates/proposal_estimate.html
+++ b/web_templates/proposal_estimate.html
@@ -51,7 +51,7 @@
                     <td><input type="text" name="unit" value="{{ it.unit }}" style="width:100%;"></td>
                     <td><input type="number" step="any" name="unit_cost" value="{{ it.unit_cost }}" class="est-cost" style="width:100%;"></td>
                     <td class="est-total">0.00</td>
-                    <td><button type="button" class="link-button est-del" title="Remove">&times;</button></td>
+                    <td><button type="button" class="link-button est-del" title="Remove line" aria-label="Remove line">&times;</button></td>
                 </tr>
                 {% endfor %}
             </tbody>
@@ -92,7 +92,7 @@
         <td><input type="text" name="unit" style="width:100%;"></td>
         <td><input type="number" step="any" name="unit_cost" value="0" class="est-cost" style="width:100%;"></td>
         <td class="est-total">0.00</td>
-        <td><button type="button" class="link-button est-del" title="Remove">&times;</button></td>
+        <td><button type="button" class="link-button est-del" title="Remove line" aria-label="Remove line">&times;</button></td>
     </tr>
 </template>
 

--- a/web_templates/proposal_reviews.html
+++ b/web_templates/proposal_reviews.html
@@ -156,7 +156,7 @@
                 <span style="color:var(--gray-500);font-size:12px;">{{ c.section_heading }}</span>
                 {% endif %}
                 <span style="margin-left:auto;color:var(--gray-500);font-size:12px;">
-                    {{ c.author.display_name or c.author.username }} &mdash; {{ c.created_at.strftime('%Y-%m-%d %H:%M') }}
+                    {{ c.author.display_name or c.author.username }} &mdash; {{ c.created_at | localtime('full') }}
                 </span>
             </div>
 
@@ -177,7 +177,7 @@
                 <strong>Resolution:</strong> {{ c.resolution_note }}
                 <span style="color:var(--gray-500);font-size:12px;">
                     &mdash; {{ c.resolver.display_name or c.resolver.username if c.resolver else '' }}
-                    {{ c.resolved_at.strftime('%Y-%m-%d %H:%M') if c.resolved_at else '' }}
+                    {% if c.resolved_at %}{{ c.resolved_at | localtime('full') }}{% endif %}
                 </span>
             </div>
             {% endif %}

--- a/web_templates/proposal_version.html
+++ b/web_templates/proposal_version.html
@@ -12,7 +12,7 @@
                 <span class="badge badge-{{ 'status-active' if version.edit_source == 'ai' else 'status-submitted' }}">
                     {{ 'AI Generated' if version.edit_source == 'ai' else 'Human Edited' }}
                 </span>
-                &mdash; {{ version.created_at.strftime('%Y-%m-%d %H:%M') }}
+                &mdash; {{ version.created_at | localtime('full') }}
             </p>
             {% if version.change_summary %}
             <p class="page-subtitle" style="margin-top:4px;">{{ version.change_summary }}</p>

--- a/web_templates/proposals.html
+++ b/web_templates/proposals.html
@@ -191,6 +191,13 @@
         {% endfor %}
     </tbody>
 </table>
+{% set pg_args = {'filter': active_filter, 'q': q, 'status': f_status,
+                  'vertical': f_vertical, 'sort': sort, 'dir': direction,
+                  'view': view} %}
+{% include "_pagination.html" %}
+{% if total_rows > per_page %}
+<p class="form-hint" style="text-align:center; margin-top:4px;">Showing {{ rows | length }} of {{ total_rows }} proposals</p>
+{% endif %}
 {% else %}
 <div class="empty-state">
     <p>No proposals match this view. <a href="{{ url_for('new_project') }}">Start a new proposal</a> or <a href="{{ url_for('proposals_list') }}">clear filters</a>.</p>

--- a/web_templates/settings.html
+++ b/web_templates/settings.html
@@ -35,32 +35,33 @@
             </div>
         </div>
         <div class="form-group">
-            <label for="company_name">Company Name</label>
-            <input type="text" id="company_name" name="company_name" value="{{ current_user.company_name }}">
+            <label for="company_name">Company Name <span class="form-hint">(workspace-wide — brands every member's proposals)</span></label>
+            <input type="text" id="company_name" name="company_name" value="{{ org.name if org else '' }}"{% if not current_user.is_admin %} readonly title="Only workspace admins can rename the company"{% endif %}>
+            {% if not current_user.is_admin %}<span class="form-hint">Only workspace admins can change this.</span>{% endif %}
         </div>
-        <!-- Preserve logo preferences when saving this form -->
-        <input type="hidden" name="company_logo_placement" value="{{ current_user.company_logo_placement or 'top_left' }}">
-        {% if current_user.company_logo_use_in_proposals %}<input type="hidden" name="company_logo_use_in_proposals" value="1">{% endif %}
-        {% if current_user.company_logo_show_on_cover %}<input type="hidden" name="company_logo_show_on_cover" value="1">{% endif %}
+        <!-- Preserve workspace logo preferences when saving this form -->
+        <input type="hidden" name="company_logo_placement" value="{{ (org.logo_placement if org else '') or 'top_left' }}">
+        {% if org and org.logo_use_in_proposals %}<input type="hidden" name="company_logo_use_in_proposals" value="1">{% endif %}
+        {% if org and org.logo_show_on_cover %}<input type="hidden" name="company_logo_show_on_cover" value="1">{% endif %}
 
         <h2 style="margin-top: 22px;">AI Provider</h2>
         <div class="form-row">
             <div class="form-group">
                 <label for="llm_provider">AI LLM Provider</label>
                 <select id="llm_provider" name="llm_provider">
-                    <option value="anthropic" {{ 'selected' if current_user.llm_provider == 'anthropic' }}>Anthropic (Claude)</option>
-                    <option value="openai" {{ 'selected' if current_user.llm_provider == 'openai' }}>OpenAI (GPT)</option>
-                    <option value="google" {{ 'selected' if current_user.llm_provider == 'google' }}>Google (Gemini)</option>
+                    <option value="anthropic" selected>Anthropic (Claude)</option>
                 </select>
             </div>
             <div class="form-group">
                 <label for="llm_model">Model</label>
+                {% set known_models = ['claude-opus-4-8', 'claude-sonnet-5', 'claude-haiku-4-5-20251001'] %}
                 <select id="llm_model" name="llm_model">
-                    <optgroup label="Anthropic">
-                        <option value="claude-opus-4-6" {{ 'selected' if current_user.llm_model == 'claude-opus-4-6' }}>Claude Opus 4.6</option>
-                        <option value="claude-sonnet-4-6" {{ 'selected' if current_user.llm_model == 'claude-sonnet-4-6' }}>Claude Sonnet 4.6</option>
-                        <option value="claude-haiku-4-5-20251001" {{ 'selected' if current_user.llm_model == 'claude-haiku-4-5-20251001' }}>Claude Haiku 4.5</option>
-                    </optgroup>
+                    <option value="claude-opus-4-8" {{ 'selected' if current_user.llm_model == 'claude-opus-4-8' }}>Claude Opus 4.8 (recommended)</option>
+                    <option value="claude-sonnet-5" {{ 'selected' if current_user.llm_model == 'claude-sonnet-5' }}>Claude Sonnet 5 (faster)</option>
+                    <option value="claude-haiku-4-5-20251001" {{ 'selected' if current_user.llm_model == 'claude-haiku-4-5-20251001' }}>Claude Haiku 4.5 (lightest)</option>
+                    {% if current_user.llm_model and current_user.llm_model not in known_models %}
+                    <option value="{{ current_user.llm_model }}" selected>{{ current_user.llm_model }} (current)</option>
+                    {% endif %}
                 </select>
             </div>
         </div>
@@ -82,6 +83,27 @@
             </select>
         </div>
         <button type="submit" class="btn btn-primary">Save Settings</button>
+    </form>
+</div>
+
+<div class="card" style="max-width: 760px;">
+    <h2>Change Password</h2>
+    <form method="post" action="{{ url_for('change_password') }}">
+        <div class="form-group">
+            <label for="current_password">Current Password</label>
+            <input type="password" id="current_password" name="current_password" required autocomplete="current-password">
+        </div>
+        <div class="form-row">
+            <div class="form-group">
+                <label for="new_password">New Password <span class="form-hint">(min 8 characters)</span></label>
+                <input type="password" id="new_password" name="new_password" required minlength="8" autocomplete="new-password">
+            </div>
+            <div class="form-group">
+                <label for="confirm_password">Confirm New Password</label>
+                <input type="password" id="confirm_password" name="confirm_password" required minlength="8" autocomplete="new-password">
+            </div>
+        </div>
+        <button type="submit" class="btn btn-secondary">Update Password</button>
     </form>
 </div>
 

--- a/web_templates/settings.html
+++ b/web_templates/settings.html
@@ -107,6 +107,39 @@
     </form>
 </div>
 
+<div class="card" style="max-width: 760px;">
+    <h2>Two-Factor Authentication</h2>
+    {% if twofa_enabled %}
+    <p class="card-desc">
+        <span class="chip chip-ok"><span class="chip-dot"></span>On</span>
+        Your account asks for a code from your authenticator app at sign-in.
+        {{ backup_codes_left }} backup code(s) remaining.
+    </p>
+    <div style="display:flex; gap:20px; flex-wrap:wrap; margin-top:12px;">
+        <form method="post" action="{{ url_for('twofa_regenerate_codes') }}" style="flex:1; min-width:240px;">
+            <div class="form-group">
+                <label>Regenerate backup codes <span class="form-hint">(invalidates old ones)</span></label>
+                <input type="text" name="code" placeholder="Current 6-digit code" inputmode="numeric" required>
+            </div>
+            <button type="submit" class="btn btn-secondary">Regenerate codes</button>
+        </form>
+        <form method="post" action="{{ url_for('twofa_disable') }}" style="flex:1; min-width:240px;"
+              onsubmit="return confirm('Turn off two-factor authentication?');">
+            <div class="form-group">
+                <label>Turn off 2FA <span class="form-hint">(confirm your password)</span></label>
+                <input type="password" name="password" placeholder="Current password" autocomplete="current-password" required>
+            </div>
+            <button type="submit" class="btn btn-danger">Disable 2FA</button>
+        </form>
+    </div>
+    {% else %}
+    <p class="card-desc">Add a second step at sign-in using an authenticator app (Google Authenticator, Authy, 1Password&hellip;). Strongly recommended for admins.</p>
+    <form method="post" action="{{ url_for('twofa_start') }}">
+        <button type="submit" class="btn btn-primary">Set up two-factor authentication</button>
+    </form>
+    {% endif %}
+</div>
+
 <div class="posture-callout" style="max-width: 760px;">
     <span>&#128737;</span>
     <div>

--- a/web_templates/signup.html
+++ b/web_templates/signup.html
@@ -36,21 +36,21 @@
                 <div class="form-row">
                     <div class="form-group">
                         <label for="username">Username *</label>
-                        <input type="text" id="username" name="username" required autofocus autocomplete="username">
+                        <input type="text" id="username" name="username" required autofocus autocomplete="username" value="{{ form.get('username', '') if form else '' }}">
                     </div>
                     <div class="form-group">
                         <label for="display_name">Display Name</label>
-                        <input type="text" id="display_name" name="display_name" placeholder="Your full name" autocomplete="name">
+                        <input type="text" id="display_name" name="display_name" placeholder="Your full name" autocomplete="name" value="{{ form.get('display_name', '') if form else '' }}">
                     </div>
                 </div>
                 <div class="form-group">
                     <label for="email">Email Address *</label>
-                    <input type="email" id="email" name="email" required autocomplete="email" value="{{ invitation.email if invitation else '' }}">
+                    <input type="email" id="email" name="email" required autocomplete="email" value="{{ invitation.email if invitation else (form.get('email', '') if form else '') }}">
                 </div>
                 <div class="form-group">
                     <label for="company_name">{% if invitation %}Workspace{% else %}Company Name{% endif %}</label>
                     <input type="text" id="company_name" name="company_name" autocomplete="organization"
-                           value="{{ invite_org.name if invite_org else '' }}"{% if invitation %} readonly{% endif %}>
+                           value="{{ invite_org.name if invite_org else (form.get('company_name', '') if form else '') }}"{% if invitation %} readonly{% endif %}>
                 </div>
                 <div class="form-group">
                     <label for="password">Password * <span class="form-hint">(min 8 characters)</span></label>

--- a/web_templates/twofa_backup_codes.html
+++ b/web_templates/twofa_backup_codes.html
@@ -1,0 +1,26 @@
+{% extends "base.html" %}
+{% block title %}Backup Codes &mdash; {{ app_name }}{% endblock %}
+{% block breadcrumb %}
+<a href="{{ url_for('settings') }}">Profile &amp; AI Settings</a>
+<span class="crumb-sep">&rsaquo;</span>
+<span class="crumb-current">Backup Codes</span>
+{% endblock %}
+
+{% block content %}
+<section class="page-header">
+    <h1>{% if first_time %}Two-factor is on &mdash; save your backup codes{% else %}Your new backup codes{% endif %}</h1>
+    <p class="page-subtitle">Each code works once if you lose access to your authenticator. Store them somewhere safe &mdash; <strong>they won't be shown again.</strong></p>
+</section>
+
+<div class="card" style="max-width: 520px;">
+    <ul style="columns: 2; list-style: none; padding: 0; font-family: monospace; font-size: 16px; letter-spacing: 1px;">
+        {% for code in codes %}
+        <li style="padding: 6px 0;">{{ code }}</li>
+        {% endfor %}
+    </ul>
+    <div class="form-actions" style="margin-top: 8px;">
+        <button type="button" class="btn btn-secondary" onclick="navigator.clipboard.writeText({{ codes | tojson }}.join('\n'))">Copy all</button>
+        <a href="{{ url_for('settings') }}" class="btn btn-primary">I've saved them &rarr;</a>
+    </div>
+</div>
+{% endblock %}

--- a/web_templates/twofa_setup.html
+++ b/web_templates/twofa_setup.html
@@ -1,0 +1,33 @@
+{% extends "base.html" %}
+{% block title %}Set up Two-Factor &mdash; {{ app_name }}{% endblock %}
+{% block breadcrumb %}
+<a href="{{ url_for('settings') }}">Profile &amp; AI Settings</a>
+<span class="crumb-sep">&rsaquo;</span>
+<span class="crumb-current">Two-Factor Setup</span>
+{% endblock %}
+
+{% block content %}
+<section class="page-header">
+    <h1>Set up two-factor authentication</h1>
+    <p class="page-subtitle">Scan the QR code with an authenticator app (Google Authenticator, Authy, 1Password&hellip;), then enter the 6-digit code it shows to confirm.</p>
+</section>
+
+<div class="card" style="max-width: 560px;">
+    <div style="text-align:center; margin-bottom: 16px;">
+        <img src="{{ qr }}" alt="Two-factor QR code" width="220" height="220"
+             style="border:1px solid var(--line); border-radius:12px; padding:8px; background:#fff;">
+    </div>
+    <p class="form-hint" style="text-align:center;">Can't scan? Enter this key manually:</p>
+    <p style="text-align:center; font-family: monospace; font-size: 15px; letter-spacing: 2px; word-break: break-all;">{{ secret }}</p>
+
+    <form method="post" action="{{ url_for('twofa_enable') }}" style="margin-top: 18px;">
+        <div class="form-group">
+            <label for="code">6-digit code from your app</label>
+            <input type="text" id="code" name="code" required autofocus autocomplete="one-time-code"
+                   inputmode="numeric" placeholder="123456" style="letter-spacing:2px;">
+        </div>
+        <button type="submit" class="btn btn-primary">Confirm &amp; turn on 2FA</button>
+        <a href="{{ url_for('settings') }}" class="btn btn-secondary">Cancel</a>
+    </form>
+</div>
+{% endblock %}


### PR DESCRIPTION
P0-1 Org templates now load on the default Auto-Detect path: the vertical
     is resolved (approved scope -> keyword detection) BEFORE template
     queries, which previously ran with the literal string "auto" and
     matched nothing. Template selection also falls back to the org's
     'general' templates per template_type, and pulls files from object
     storage when the local copy is missing.

P0-2 The clarification Q&A loop now closes: answered questions are passed
     into generate_proposal on regeneration, re-asked duplicates no longer
     halt the run or duplicate register rows (they fall through and the
     proposal is saved), and question-only runs no longer consume the
     monthly generation quota (billing counts in-flight jobs plus
     proposals actually produced).

P0-3 Hosted multi-tenant generations no longer inject the install-level
     sample boilerplate, reference proposals, or vertical company
     boilerplate into the prompt (generate_proposal gains
     include_global_boilerplate, driven by SELF_HOSTED). The data_center
     vertical workflow/template shipped with a specific company's name
     baked in; those files are genericized to "the Company".

P0-4 Proposal reads are now DB-canonical via _proposal_markdown (latest
     ProposalVersion first, generated file as legacy fallback) in the
     viewer, editor, review pages, section regeneration, and addendum
     analysis; edit/apply-feedback/restore/section-regen writes mirror
     md+docx to object storage; RFP text assembly and document
     download/preview/bulk-zip fetch from object storage when the local
     copy is missing. Fixes lost/stale proposals on redeploys and
     multi-instance deployments.

P0-5 The customer portal renders the version pinned at share time instead
     of the live latest, so internal edits after submission never silently
     change what the customer sees or accepted. The share card shows which
     version the customer sees and offers a one-click re-pin to latest;
     legacy unpinned shares fall back to latest.

Adds test_p0_fixes.py (26 regression tests) covering all five fixes;
existing suites (304 tests) unchanged and passing.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01W9UEumvTkCi2sAxAi4jFRZ