### PR TITLE
Jobify the last inline AI calls + fix job redirects in production workers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,10 @@
 # Anthropic API Key (required)
 ANTHROPIC_API_KEY=your-api-key-here
 
+# Small/fast model used to classify RFPs into an industry vertical during
+# generation (falls back to keyword matching on error / no key).
+# CLAUDE_CLASSIFIER_MODEL=claude-haiku-4-5
+
 # Docker host port (the port you access the app on).
 # Default is 15010 (production deployment); nginx proxies 80/443 to this port.
 HOST_PORT=15010

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,46 @@
+name: tests
+
+on:
+  push:
+  pull_request:
+
+# A superseded push cancels the older in-flight run for the same ref.
+concurrency:
+  group: tests-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"  # matches the python:3.12-slim Docker base
+          cache: pip
+
+      - name: Install Tesseract OCR
+        # test_ocr's real-recognition checks SKIP gracefully without it;
+        # installing it makes CI exercise the full OCR path like production.
+        run: sudo apt-get update && sudo apt-get install -y tesseract-ocr
+
+      - name: Install Python dependencies
+        run: pip install -r requirements.txt
+
+      - name: Run all test suites
+        # Every suite is a standalone script (python test_X.py, exit code 0/1).
+        # Run them ALL even after a failure so one broken suite doesn't hide
+        # the state of the others; fail the job if any failed.
+        run: |
+          rc=0
+          for t in test_*.py; do
+            echo "::group::$t"
+            if ! python "$t"; then
+              rc=1
+              echo "::error title=$t failed::$t exited non-zero"
+            fi
+            echo "::endgroup::"
+          done
+          exit $rc

--- a/app.py
+++ b/app.py
@@ -8012,64 +8012,92 @@ def calendar_view():
 @app.route("/reports")
 @login_required
 def reports():
-    """Win/loss analysis, pipeline trends, vertical performance."""
-    from sqlalchemy import func
-    from collections import OrderedDict, Counter
+    """Win/loss analysis, pipeline trends, vertical performance.
+
+    Every section aggregates in SQL (grouped counts/sums, like _counts_by and
+    the admin panel) so the page stays flat-cost as a tenant's history grows —
+    previously every project row was loaded into Python and bucketed there,
+    which degraded linearly and would eventually blow the request out of
+    memory on a large org."""
+    from sqlalchemy import case, func
+    from collections import OrderedDict
 
     # Admins see company-wide; other users see own + assigned
     if current_user.is_admin:
-        base_query = Project.query.filter_by(org_id=current_user.org_id)
+        scope = [Project.org_id == current_user.org_id]
     else:
-        base_query = Project.query.filter(_my_projects_filter())
+        scope = [_my_projects_filter()]
+    decided = Project.status.in_(("won", "lost"))
+    amount = func.coalesce(func.sum(Project.dollar_amount), 0.0)
 
-    all_projects = base_query.all()
-
-    # Overall stats
-    won_projects = [p for p in all_projects if p.status == "won"]
-    lost_projects = [p for p in all_projects if p.status == "lost"]
-    total_won = len(won_projects)
-    total_lost = len(lost_projects)
+    # Overall stats: one pass grouped by status
+    by_status = {
+        status: {"count": count, "value": value or 0}
+        for status, count, value in (
+            db.session.query(Project.status, func.count(Project.id), amount)
+            .filter(*scope).group_by(Project.status).all()
+        )
+    }
+    total_won = by_status.get("won", {}).get("count", 0)
+    total_lost = by_status.get("lost", {}).get("count", 0)
     total_decided = total_won + total_lost
-    overall_win_rate = round((total_won / total_decided) * 100) if total_decided else 0
-    won_value = sum(p.dollar_amount or 0 for p in won_projects)
-    lost_value = sum(p.dollar_amount or 0 for p in lost_projects)
+    stats = {
+        "total_projects": sum(e["count"] for e in by_status.values()),
+        "total_active": by_status.get("active", {}).get("count", 0),
+        "total_submitted": by_status.get("submitted", {}).get("count", 0),
+        "total_won": total_won,
+        "total_lost": total_lost,
+        "win_rate": round((total_won / total_decided) * 100) if total_decided else 0,
+        "won_value": by_status.get("won", {}).get("value", 0),
+        "lost_value": by_status.get("lost", {}).get("value", 0),
+    }
 
-    # Win/loss by vertical
+    # Win/loss by vertical: grouped by (label, status). NULL and "" both
+    # collapse to "General", matching the old `label or "General"`.
+    label_col = func.coalesce(func.nullif(Project.vertical_label, ""), "General")
     vertical_stats = {}
-    for p in all_projects:
-        label = p.vertical_label or "General"
-        vs = vertical_stats.setdefault(label, {"won": 0, "lost": 0, "won_value": 0, "lost_value": 0, "active": 0})
-        if p.status == "won":
-            vs["won"] += 1
-            vs["won_value"] += p.dollar_amount or 0
-        elif p.status == "lost":
-            vs["lost"] += 1
-            vs["lost_value"] += p.dollar_amount or 0
-        elif p.status == "active":
-            vs["active"] += 1
-
-    for label, vs in vertical_stats.items():
-        decided = vs["won"] + vs["lost"]
-        vs["win_rate"] = round((vs["won"] / decided) * 100) if decided else 0
+    for label, status, count, value in (
+        db.session.query(label_col, Project.status, func.count(Project.id), amount)
+        .filter(*scope).group_by(label_col, Project.status).all()
+    ):
+        vs = vertical_stats.setdefault(
+            label, {"won": 0, "lost": 0, "won_value": 0, "lost_value": 0, "active": 0}
+        )
+        if status == "won":
+            vs["won"], vs["won_value"] = count, value or 0
+        elif status == "lost":
+            vs["lost"], vs["lost_value"] = count, value or 0
+        elif status == "active":
+            vs["active"] = count
+    for vs in vertical_stats.values():
+        vertical_decided = vs["won"] + vs["lost"]
+        vs["win_rate"] = round((vs["won"] / vertical_decided) * 100) if vertical_decided else 0
         vs["total_value"] = vs["won_value"] + vs["lost_value"]
+    # Biggest book of business first (was arbitrary iteration order)
+    vertical_stats = dict(
+        sorted(vertical_stats.items(), key=lambda kv: (-kv[1]["total_value"], kv[0]))
+    )
 
-    # Top competitors
-    competitor_counter = Counter()
-    competitor_wins = Counter()
-    for p in won_projects + lost_projects:
-        if p.competitor_name:
-            competitor_counter[p.competitor_name] += 1
-            if p.status == "won":
-                competitor_wins[p.competitor_name] += 1
+    # Top competitors: grouped, capped in SQL
     top_competitors = []
-    for name, total in competitor_counter.most_common(10):
-        wins = competitor_wins.get(name, 0)
-        losses = total - wins
+    for name, total, wins in (
+        db.session.query(
+            Project.competitor_name,
+            func.count(Project.id),
+            func.sum(case((Project.status == "won", 1), else_=0)),
+        )
+        .filter(*scope, decided,
+                Project.competitor_name.isnot(None), Project.competitor_name != "")
+        .group_by(Project.competitor_name)
+        .order_by(func.count(Project.id).desc(), Project.competitor_name.asc())
+        .limit(10).all()
+    ):
+        wins = int(wins or 0)
         top_competitors.append({
             "name": name,
             "total": total,
             "wins": wins,
-            "losses": losses,
+            "losses": total - wins,
             "win_rate": round((wins / total) * 100) if total else 0,
         })
 
@@ -8085,60 +8113,60 @@ def reports():
     }
     won_category_counts = {k: 0 for k in category_labels}
     lost_category_counts = {k: 0 for k in category_labels}
-    for p in won_projects:
-        key = p.close_category or "other"
-        if key in won_category_counts:
-            won_category_counts[key] += 1
-    for p in lost_projects:
-        key = p.close_category or "other"
-        if key in lost_category_counts:
-            lost_category_counts[key] += 1
+    cat_col = func.coalesce(func.nullif(Project.close_category, ""), "other")
+    for status, key, count in (
+        db.session.query(Project.status, cat_col, func.count(Project.id))
+        .filter(*scope, decided).group_by(Project.status, cat_col).all()
+    ):
+        target = won_category_counts if status == "won" else lost_category_counts
+        if key in target:  # unknown categories are dropped, as before
+            target[key] += count
 
-    # Monthly trend (last 6 months of closures)
-    from datetime import timedelta
+    # Monthly trend (last 6 calendar months of closures), bucketed in SQL
     now = datetime.now(timezone.utc).replace(tzinfo=None)
     trend = OrderedDict()
     for i in range(5, -1, -1):
-        # Approximate by calendar month
         m = now.month - i
         y = now.year
         while m <= 0:
             m += 12
             y -= 1
-        key = f"{y}-{m:02d}"
-        trend[key] = {"won": 0, "lost": 0, "won_value": 0, "lost_value": 0}
+        trend[f"{y}-{m:02d}"] = {"won": 0, "lost": 0, "won_value": 0, "lost_value": 0}
+    oldest_year, oldest_month = (int(x) for x in next(iter(trend)).split("-"))
+    window_start = datetime(oldest_year, oldest_month, 1)
 
-    for p in won_projects + lost_projects:
-        when = p.closed_at or p.submitted_at or p.updated_at
-        if not when:
+    closed_when = func.coalesce(Project.closed_at, Project.submitted_at, Project.updated_at)
+    if db.engine.dialect.name == "postgresql":
+        month_col = func.to_char(closed_when, "YYYY-MM")
+    else:  # sqlite
+        month_col = func.strftime("%Y-%m", closed_when)
+    for key, status, count, value in (
+        db.session.query(month_col, Project.status, func.count(Project.id), amount)
+        .filter(*scope, decided, closed_when >= window_start)
+        .group_by(month_col, Project.status).all()
+    ):
+        if key not in trend:
             continue
-        when = when.replace(tzinfo=None) if when.tzinfo else when
-        key = f"{when.year}-{when.month:02d}"
-        if key in trend:
-            if p.status == "won":
-                trend[key]["won"] += 1
-                trend[key]["won_value"] += p.dollar_amount or 0
-            else:
-                trend[key]["lost"] += 1
-                trend[key]["lost_value"] += p.dollar_amount or 0
+        if status == "won":
+            trend[key]["won"], trend[key]["won_value"] = count, value or 0
+        else:
+            trend[key]["lost"], trend[key]["lost_value"] = count, value or 0
 
-    # Recently closed projects with missing details (prompt user to fill in)
-    missing_details = [
-        p for p in (won_projects + lost_projects)
-        if not (p.close_reason or p.close_category or p.competitor_name)
-    ]
-    missing_details.sort(key=lambda p: p.closed_at or p.updated_at or now, reverse=True)
+    # Recently closed projects with missing details (prompt user to fill in) —
+    # filtered, ordered, and capped in SQL instead of materializing every row.
+    def _blank(col):
+        return db.or_(col.is_(None), col == "")
 
-    stats = {
-        "total_projects": len(all_projects),
-        "total_active": sum(1 for p in all_projects if p.status == "active"),
-        "total_submitted": sum(1 for p in all_projects if p.status == "submitted"),
-        "total_won": total_won,
-        "total_lost": total_lost,
-        "win_rate": overall_win_rate,
-        "won_value": won_value,
-        "lost_value": lost_value,
-    }
+    missing_details = (
+        Project.query.filter(
+            *scope, decided,
+            _blank(Project.close_reason),
+            _blank(Project.close_category),
+            _blank(Project.competitor_name),
+        )
+        .order_by(func.coalesce(Project.closed_at, Project.updated_at).desc())
+        .limit(10).all()
+    )
 
     return render_template(
         "reports.html",
@@ -8149,7 +8177,7 @@ def reports():
         lost_category_counts=lost_category_counts,
         category_labels=category_labels,
         trend=trend,
-        missing_details=missing_details[:10],
+        missing_details=missing_details,
     )
 
 

--- a/app.py
+++ b/app.py
@@ -118,6 +118,7 @@ from models import (
 )
 from proposal_agent import (
     analyze_addendum_impact,
+    classify_vertical,
     draft_estimate,
     draft_scope_of_work,
     extract_rates_from_sheet,
@@ -3671,8 +3672,11 @@ def _perform_generation(project_id, user, vertical, output_format, cost_options,
         if scope and scope.status == "approved" and scope.vertical:
             vertical = scope.vertical
         else:
-            from document_parser import detect_vertical
-            vertical = detect_vertical(combined_text)
+            set_progress("reading", "Detecting the industry vertical…")
+            vertical = classify_vertical(
+                combined_text,
+                user_api_key=decrypt_api_key(user.api_key_encrypted) or None,
+            )
 
     org_id = user.org_id
     include_staff_types = cost_options.get("include_staff_types")

--- a/app.py
+++ b/app.py
@@ -436,6 +436,27 @@ def _record_signup(ip: str):
     _SIGNUP_ATTEMPTS.setdefault(ip, []).append(time.time())
 
 
+# Forgot-password throttle: the endpoint is unauthenticated and sends email,
+# which makes it both an inbox-bombing vector (spam a victim with reset mail)
+# and an SMTP-budget drain. Limited per requesting IP and per target email;
+# throttled requests still get the same generic response so a prober can't
+# tell the difference.
+_RESET_REQUESTS: dict[str, list[float]] = {}
+_RESET_MAX_PER_WINDOW = 5
+_RESET_WINDOW_SECONDS = 3600
+
+
+def _reset_rate_limited(key: str) -> bool:
+    now = time.time()
+    attempts = [t for t in _RESET_REQUESTS.get(key, []) if now - t < _RESET_WINDOW_SECONDS]
+    _RESET_REQUESTS[key] = attempts
+    return len(attempts) >= _RESET_MAX_PER_WINDOW
+
+
+def _record_reset_request(key: str):
+    _RESET_REQUESTS.setdefault(key, []).append(time.time())
+
+
 # In-process AI-endpoint throttle (chat / editor assist) per user.
 _AI_CALLS: dict[str, list[float]] = {}
 
@@ -1393,6 +1414,16 @@ def forgot_password():
     email = request.form.get("email", "").strip().lower()
     # Always show the same message to avoid leaking which emails exist
     generic = "If an account exists for that email, a reset link has been sent."
+    if not app.testing and (
+        _reset_rate_limited(f"ip:{request.remote_addr}")
+        or (email and _reset_rate_limited(f"em:{email}"))
+    ):
+        # Same response as success — no token issued, no email sent
+        flash(generic, "success")
+        return redirect(url_for("login"))
+    _record_reset_request(f"ip:{request.remote_addr}")
+    if email:
+        _record_reset_request(f"em:{email}")
     user = User.query.filter(_email_matches(email)).first() if email else None
     if user:
         raw = _issue_token(user, "reset", hours=2)

--- a/app.py
+++ b/app.py
@@ -2621,7 +2621,9 @@ _INGEST_TARGETS = {
 @app.route("/posture/ingest-rates", methods=["POST"])
 @login_required
 def ingest_rates():
-    """Parse an uploaded rate sheet and AI-map it into structured rows for review."""
+    """Accept a rate-sheet upload and hand the AI extraction to a background
+    job — the Claude mapping call takes long enough to hold a web worker.
+    The review screen then reads the extracted rows from the job's result."""
     file = request.files.get("ingest_file")
     target = request.form.get("target_type", "labor_rates")
     if target not in _INGEST_TARGETS:
@@ -2633,7 +2635,32 @@ def ingest_rates():
         flash("Please upload an Excel, CSV, PDF, or Word file.", "error")
         return redirect(url_for("posture"))
 
+    # Abuse gate: platform-key AI requires a verified email
+    ok, msg = _platform_ai_gate()
+    if not ok:
+        flash(msg, "error")
+        return redirect(url_for("posture") + _INGEST_TARGETS[target]["anchor"])
+
     safe, path, size = _save_upload(file, f"ingest/{current_user.org_id}")
+    job = jobs.enqueue(
+        "ingest_rates",
+        {"path": path, "source_name": safe, "target": target},
+        user_id=current_user.id,
+        org_id=current_user.org_id,
+    )
+    return redirect(url_for("job_status_page", job_id=job.id))
+
+
+def _perform_rates_ingest(payload, job, set_progress):
+    """Parse an uploaded rate sheet and AI-map it into structured rows for
+    review. Runs inside a background job; rows land in job.result and the
+    /posture/ingest-review/<job_id> page renders them for confirmation."""
+    path = payload["path"]
+    target = payload["target"]
+    user = db.session.get(User, job.user_id)
+
+    set_progress("reading", "Reading the uploaded file…")
+    storage.ensure_local(path)
     try:
         if path.lower().endswith((".xlsx", ".xls")):
             parsed = parse_rate_sheet(path)
@@ -2641,33 +2668,41 @@ def ingest_rates():
         elif path.lower().endswith(".csv"):
             raw_text = Path(path).read_text(encoding="utf-8", errors="replace")
         else:
-            raw_text = parse_document(path)
+            # Scanned PDFs are fair game here — OCR is allowed inside jobs.
+            raw_text = parse_document(path, ocr=True)
     except Exception as e:
-        flash(f"Could not read the file: {e}", "error")
-        return redirect(url_for("posture") + _INGEST_TARGETS[target]["anchor"])
+        raise RuntimeError(f"Could not read the file: {e}")
 
+    set_progress("drafting", "Claude is mapping rows for your review…")
     try:
         rows = extract_rates_from_sheet(
             raw_text, target,
-            user_api_key=decrypt_api_key(current_user.api_key_encrypted) or None,
-            user_model=current_user.llm_model or None,
+            user_api_key=decrypt_api_key(user.api_key_encrypted) or None,
+            user_model=user.llm_model or None,
         )
-    except RuntimeError as e:
-        flash(str(e), "error")
-        return redirect(url_for("posture") + _INGEST_TARGETS[target]["anchor"])
+    except RuntimeError:
+        raise
     except Exception as e:
-        flash(f"Extraction failed: {friendly_api_error(e)}", "error")
-        return redirect(url_for("posture") + _INGEST_TARGETS[target]["anchor"])
+        raise RuntimeError(f"Extraction failed: {friendly_api_error(e)}")
 
     if not rows:
-        flash("The AI couldn't find any rows to import. You can still add rates manually.", "error")
-        return redirect(url_for("posture") + _INGEST_TARGETS[target]["anchor"])
+        raise RuntimeError(
+            "The AI couldn't find any rows to import. You can still add rates manually."
+        )
+    set_progress("saving", "Preparing the review table…")
+    return {
+        "redirect": url_for("ingest_review", job_id=job.id),
+        "rows": rows,
+        "target": target,
+        "source_name": payload.get("source_name", ""),
+    }
 
-    return render_template(
-        "ingest_review.html",
-        mode="rates", target=target, meta=_INGEST_TARGETS[target],
-        rows=rows, source_name=safe,
-    )
+
+@jobs.register("ingest_rates")
+def _job_ingest_rates(payload, job):
+    def _sp(phase, message=""):
+        jobs.set_progress(job, phase, message)
+    return _perform_rates_ingest(payload, job, _sp)
 
 
 @app.route("/posture/ingest-rates/confirm", methods=["POST"])
@@ -2733,7 +2768,8 @@ def ingest_rates_confirm():
 @app.route("/posture/ingest-standards", methods=["POST"])
 @login_required
 def ingest_standards():
-    """Parse a document and propose reusable company standard blocks for review."""
+    """Accept a standards-document upload and hand the AI extraction to a
+    background job, mirroring the rates ingest flow."""
     file = request.files.get("standards_file")
     if not file or not file.filename:
         flash("Please choose a document to import.", "error")
@@ -2741,28 +2777,94 @@ def ingest_standards():
     if not _allowed_file(file.filename, INGEST_STANDARDS_EXTENSIONS):
         flash("Please upload a PDF, Word, or text document.", "error")
         return redirect(url_for("posture") + "#standards")
-    safe, path, size = _save_upload(file, f"ingest/{current_user.org_id}")
-    try:
-        text = parse_document(path)
-    except Exception as e:
-        flash(f"Could not read the document: {e}", "error")
+
+    # Abuse gate: platform-key AI requires a verified email
+    ok, msg = _platform_ai_gate()
+    if not ok:
+        flash(msg, "error")
         return redirect(url_for("posture") + "#standards")
+
+    safe, path, size = _save_upload(file, f"ingest/{current_user.org_id}")
+    job = jobs.enqueue(
+        "ingest_standards",
+        {"path": path, "source_name": safe},
+        user_id=current_user.id,
+        org_id=current_user.org_id,
+    )
+    return redirect(url_for("job_status_page", job_id=job.id))
+
+
+def _perform_standards_ingest(payload, job, set_progress):
+    """Parse a document and propose reusable company standard blocks. Runs
+    inside a background job; blocks land in job.result for the review page."""
+    path = payload["path"]
+    user = db.session.get(User, job.user_id)
+
+    set_progress("reading", "Reading the document…")
+    storage.ensure_local(path)
+    try:
+        text = parse_document(path, ocr=True)
+    except Exception as e:
+        raise RuntimeError(f"Could not read the document: {e}")
+
+    set_progress("drafting", "Claude is extracting reusable standards…")
     try:
         blocks = extract_standards(
             text,
-            user_api_key=decrypt_api_key(current_user.api_key_encrypted) or None,
-            user_model=current_user.llm_model or None,
+            user_api_key=decrypt_api_key(user.api_key_encrypted) or None,
+            user_model=user.llm_model or None,
         )
-    except RuntimeError as e:
-        flash(str(e), "error")
-        return redirect(url_for("posture") + "#standards")
+    except RuntimeError:
+        raise
     except Exception as e:
-        flash(f"Extraction failed: {friendly_api_error(e)}", "error")
-        return redirect(url_for("posture") + "#standards")
+        raise RuntimeError(f"Extraction failed: {friendly_api_error(e)}")
+
     if not blocks:
-        flash("The AI couldn't extract standards from that document.", "error")
-        return redirect(url_for("posture") + "#standards")
-    return render_template("ingest_review.html", mode="standards", blocks=blocks, source_name=safe)
+        raise RuntimeError("The AI couldn't extract standards from that document.")
+    set_progress("saving", "Preparing the review list…")
+    return {
+        "redirect": url_for("ingest_review", job_id=job.id),
+        "blocks": blocks,
+        "source_name": payload.get("source_name", ""),
+    }
+
+
+@jobs.register("ingest_standards")
+def _job_ingest_standards(payload, job):
+    def _sp(phase, message=""):
+        jobs.set_progress(job, phase, message)
+    return _perform_standards_ingest(payload, job, _sp)
+
+
+@app.route("/posture/ingest-review/<job_id>")
+@login_required
+def ingest_review(job_id):
+    """Review screen for a finished AI import job (rates or standards). The
+    extracted rows live in the job's result; the confirm POST (unchanged)
+    imports whatever the user keeps after editing."""
+    job = db.session.get(BackgroundJob, job_id)
+    if not job or job.user_id != current_user.id:
+        abort(404)
+    if job.kind not in ("ingest_rates", "ingest_standards") or job.status != "done":
+        abort(404)
+    try:
+        result = json.loads(job.result or "{}")
+    except ValueError:
+        result = {}
+    if job.kind == "ingest_rates":
+        target = result.get("target")
+        if target not in _INGEST_TARGETS:
+            abort(404)
+        return render_template(
+            "ingest_review.html",
+            mode="rates", target=target, meta=_INGEST_TARGETS[target],
+            rows=result.get("rows") or [], source_name=result.get("source_name", ""),
+        )
+    return render_template(
+        "ingest_review.html",
+        mode="standards", blocks=result.get("blocks") or [],
+        source_name=result.get("source_name", ""),
+    )
 
 
 @app.route("/posture/ingest-standards/confirm", methods=["POST"])
@@ -3888,13 +3990,27 @@ def _job_generate_proposal(payload, job):
     )
 
 
+# Human labels for the progress page, keyed by BackgroundJob.kind
+_JOB_KIND_LABELS = {
+    "generate_proposal": "Generating proposal",
+    "draft_scope": "Drafting scope of work",
+    "draft_estimate": "Drafting estimate",
+    "revise_proposal": "Applying revisions",
+    "analyze_addendum": "Analyzing addendum",
+    "regenerate_section": "Regenerating section",
+    "ingest_rates": "AI rate import",
+    "ingest_standards": "AI standards import",
+}
+
+
 @app.route("/jobs/<job_id>")
 @login_required
 def job_status_page(job_id):
     job = db.session.get(BackgroundJob, job_id)
     if not job or job.user_id != current_user.id:
         abort(404)
-    return render_template("job_status.html", job=job)
+    return render_template("job_status.html", job=job,
+                           kind_label=_JOB_KIND_LABELS.get(job.kind, "Working"))
 
 
 @app.route("/jobs/<job_id>/cancel", methods=["POST"])
@@ -8743,79 +8859,125 @@ def record_rfi_response(project_id, item_id):
 @app.route("/projects/<project_id>/addendum-analysis", methods=["POST"])
 @login_required
 def addendum_analysis(project_id):
-    """Analyze a newly uploaded addendum against existing proposal."""
+    """Analyze a newly uploaded addendum against the existing proposal — the
+    document parsing (possibly OCR) plus the AI comparison take minutes, so
+    the work runs as a background job. Cheap validations happen here first so
+    the user gets an immediate error instead of a failed job."""
     project = db.session.get(Project, project_id)
     if not _can_access_project(project):
         abort(404)
 
-    addendum_doc_id = request.form.get("addendum_doc_id")
-    addendum_doc = db.session.get(ProjectDocument, addendum_doc_id)
-    if not addendum_doc:
+    # Abuse gate: platform-key AI requires a verified email
+    ok, msg = _platform_ai_gate()
+    if not ok:
+        flash(msg, "error")
+        return redirect(url_for("project_upload", project_id=project_id))
+
+    addendum_doc_id = request.form.get("addendum_doc_id") or ""
+    addendum_doc = db.session.get(ProjectDocument, addendum_doc_id) if addendum_doc_id else None
+    # The doc must belong to THIS project — a foreign id would otherwise pull
+    # another tenant's document into the analysis.
+    if not addendum_doc or addendum_doc.project_id != project_id:
         flash("Addendum document not found.", "error")
         return redirect(url_for("project_upload", project_id=project_id))
 
-    # Get original RFP text
-    rfp_docs = ProjectDocument.query.filter_by(project_id=project_id, file_type="rfp").all()
-    original_rfp_text = ""
-    for doc in rfp_docs:
-        if doc.id != addendum_doc_id:
-            try:
-                storage.ensure_local(doc.file_path)
-                original_rfp_text += parse_document(doc.file_path) + "\n"
-            except Exception:
-                continue
-
-    # Get addendum text
-    try:
-        storage.ensure_local(addendum_doc.file_path)
-        addendum_text = parse_document(addendum_doc.file_path)
-    except Exception:
-        flash("Could not parse addendum document.", "error")
-        return redirect(url_for("project_upload", project_id=project_id))
-
-    # Get current proposal (DB version first; file fallback)
-    proposal = Proposal.query.filter_by(project_id=project_id).order_by(Proposal.generated_at.desc()).first()
-    current_md = _proposal_markdown(proposal) if proposal else ""
-
-    if not current_md:
+    proposal = (
+        Proposal.query.filter_by(project_id=project_id)
+        .order_by(Proposal.generated_at.desc()).first()
+    )
+    if not proposal or not _proposal_markdown(proposal):
         flash("No existing proposal to analyze against.", "error")
         return redirect(url_for("project_upload", project_id=project_id))
 
+    job = jobs.enqueue(
+        "analyze_addendum",
+        {"project_id": project_id, "addendum_doc_id": addendum_doc_id},
+        user_id=current_user.id,
+        org_id=current_user.org_id,
+    )
+    return redirect(url_for("job_status_page", job_id=job.id))
+
+
+def _perform_addendum_analysis(project_id, addendum_doc_id, user, set_progress):
+    """Parse the addendum + original RFP, run the AI impact comparison, and
+    file each impact into the clarification register. Runs inside a job."""
+    project = db.session.get(Project, project_id)
+    if not project:
+        raise RuntimeError("Project no longer exists.")
+    addendum_doc = db.session.get(ProjectDocument, addendum_doc_id)
+    if not addendum_doc or addendum_doc.project_id != project_id:
+        raise RuntimeError("Addendum document not found.")
+
+    set_progress("reading", "Reading the addendum and original RFP…")
+    original_rfp_text = ""
+    for doc in ProjectDocument.query.filter_by(project_id=project_id, file_type="rfp").all():
+        if doc.id == addendum_doc_id:
+            continue
+        try:
+            storage.ensure_local(doc.file_path)
+            original_rfp_text += parse_document(doc.file_path, ocr=True) + "\n"
+        except Exception:
+            continue
+
+    try:
+        storage.ensure_local(addendum_doc.file_path)
+        addendum_text = parse_document(addendum_doc.file_path, ocr=True)
+    except Exception:
+        raise RuntimeError("Could not parse the addendum document.")
+
+    # Current proposal content (DB-canonical)
+    proposal = (
+        Proposal.query.filter_by(project_id=project_id)
+        .order_by(Proposal.generated_at.desc()).first()
+    )
+    current_md = _proposal_markdown(proposal) if proposal else ""
+    if not current_md:
+        raise RuntimeError("No existing proposal to analyze against.")
+
+    set_progress("drafting", "Claude is comparing the addendum against your proposal…")
     try:
         result = analyze_addendum_impact(
             original_rfp_text, addendum_text, current_md,
-            user_api_key=decrypt_api_key(current_user.api_key_encrypted) or None,
-            user_model=current_user.llm_model or None,
+            user_api_key=decrypt_api_key(user.api_key_encrypted) or None,
+            user_model=user.llm_model or None,
         )
-
-        # Create ClarificationItems for each identified change
-        for change in result.get("changes", []):
-            ci = ClarificationItem(
-                project_id=project_id,
-                proposal_id=proposal.id if proposal else None,
-                source="addendum",
-                resolution_path="internal" if change.get("can_ai_resolve") else "internal",
-                category="scope",
-                priority=change.get("severity", "medium"),
-                question=change.get("addendum_item", ""),
-                context=change.get("impact_description", ""),
-                ai_suggestion=change.get("suggested_resolution", ""),
-                proposal_section=", ".join(change.get("affected_sections", [])),
-                status="open",
-                created_by=current_user.id,
-            )
-            db.session.add(ci)
-
-        project.clarification_sub_status = "clarification_pending"
-        db.session.commit()
-
-        _log_activity("addendum_analysis", f"Analyzed addendum: {len(result.get('changes', []))} impacts found", project_id)
-        flash(f"Addendum analysis complete: {len(result.get('changes', []))} impact(s) identified and added to clarification register.", "success")
-
+    except RuntimeError:
+        raise
     except Exception as e:
-        flash(f"Error analyzing addendum: {friendly_api_error(e)}", "error")
+        raise RuntimeError(friendly_api_error(e))
 
-    return redirect(url_for("clarification_register", project_id=project_id))
+    set_progress("saving", "Filing impacts in the clarification register…")
+    changes = result.get("changes", [])
+    for change in changes:
+        db.session.add(ClarificationItem(
+            project_id=project_id,
+            proposal_id=proposal.id,
+            source="addendum",
+            resolution_path="internal",
+            category="scope",
+            priority=change.get("severity", "medium"),
+            question=change.get("addendum_item", ""),
+            context=change.get("impact_description", ""),
+            ai_suggestion=change.get("suggested_resolution", ""),
+            proposal_section=", ".join(change.get("affected_sections", [])),
+            status="open",
+            created_by=user.id,
+        ))
+    project.clarification_sub_status = "clarification_pending"
+    db.session.commit()
+
+    _log_activity_for(user, "addendum_analysis",
+                      f"Analyzed addendum: {len(changes)} impacts found", project_id)
+    return {"redirect": url_for("clarification_register", project_id=project_id)}
+
+
+@jobs.register("analyze_addendum")
+def _job_analyze_addendum(payload, job):
+    user = db.session.get(User, job.user_id)
+    def _sp(phase, message=""):
+        jobs.set_progress(job, phase, message)
+    return _perform_addendum_analysis(
+        payload["project_id"], payload["addendum_doc_id"], user, _sp)
 
 
 # ---------------------------------------------------------------------------
@@ -8825,7 +8987,10 @@ def addendum_analysis(project_id):
 @app.route("/proposal/<proposal_id>/regenerate-section", methods=["POST"])
 @login_required
 def regenerate_proposal_section(proposal_id):
-    """Regenerate a specific section of the proposal with new clarification info."""
+    """Regenerate a specific section of the proposal with new clarification
+    info — the AI rewrite runs as a background job. Validations that need no
+    AI (missing fields, heading not present) fail fast here instead of
+    burning a job and tokens."""
     proposal = db.session.get(Proposal, proposal_id)
     if not proposal:
         abort(404)
@@ -8833,88 +8998,131 @@ def regenerate_proposal_section(proposal_id):
     if not _can_access_project(project):
         abort(404)
 
+    # Abuse gate: platform-key AI requires a verified email
+    ok, msg = _platform_ai_gate()
+    if not ok:
+        flash(msg, "error")
+        return redirect(url_for("edit_proposal", proposal_id=proposal_id))
+
     section_heading = request.form.get("section_heading", "").strip()
     clarification_answer = request.form.get("clarification_answer", "").strip()
-
     if not section_heading or not clarification_answer:
         flash("Section heading and clarification info are required.", "error")
         return redirect(url_for("edit_proposal", proposal_id=proposal_id))
 
-    # Get current proposal content (DB version first; file fallback)
-    md_path = GENERATED_DIR / proposal.md_file
     current_md = _proposal_markdown(proposal)
+    if not current_md:
+        flash("Proposal has no content to regenerate.", "error")
+        return redirect(url_for("edit_proposal", proposal_id=proposal_id))
+    if section_heading not in current_md:
+        # The replacement regex matches the heading literally — a typo would
+        # previously spend the AI call and then silently save an unchanged copy.
+        flash(f"Couldn't find '{section_heading}' in the proposal. "
+              "Copy the heading exactly as it appears in the document.", "error")
+        return redirect(url_for("edit_proposal", proposal_id=proposal_id))
 
-    # Get original RFP text for context
-    rfp_docs = ProjectDocument.query.filter_by(project_id=proposal.project_id, file_type="rfp").all()
+    job = jobs.enqueue(
+        "regenerate_section",
+        {"proposal_id": proposal_id, "section_heading": section_heading,
+         "clarification_answer": clarification_answer},
+        user_id=current_user.id,
+        org_id=current_user.org_id,
+    )
+    return redirect(url_for("job_status_page", job_id=job.id))
+
+
+def _perform_section_regeneration(proposal_id, user, section_heading,
+                                  clarification_answer, set_progress):
+    """AI-rewrite one section and save the result as a new version. Runs
+    inside a background job."""
+    proposal = db.session.get(Proposal, proposal_id)
+    if not proposal:
+        raise RuntimeError("Proposal no longer exists.")
+    project = db.session.get(Project, proposal.project_id)
+
+    current_md = _proposal_markdown(proposal)
+    if not current_md:
+        raise RuntimeError("Proposal has no content to regenerate.")
+
+    set_progress("reading", "Reading the RFP for context…")
     rfp_text = ""
-    for doc in rfp_docs:
+    for doc in ProjectDocument.query.filter_by(
+            project_id=proposal.project_id, file_type="rfp").all():
         try:
             storage.ensure_local(doc.file_path)
-            rfp_text += parse_document(doc.file_path) + "\n"
+            rfp_text += parse_document(doc.file_path, ocr=True) + "\n"
         except Exception:
             continue
 
+    _sec_org = _org_for_project(project)
+    set_progress("drafting", f"Claude is rewriting '{section_heading}'…")
     try:
-        _sec_org = _org_for_project(project)
         result = regenerate_section(
             full_proposal_md=current_md,
             section_heading=section_heading,
             clarification_answer=clarification_answer,
             original_rfp_text=rfp_text,
             company_name=(_sec_org.name if _sec_org else ""),
-            user_api_key=decrypt_api_key(current_user.api_key_encrypted) or None,
-            user_model=current_user.llm_model or None,
+            user_api_key=decrypt_api_key(user.api_key_encrypted) or None,
+            user_model=user.llm_model or None,
         )
-
-        # Replace the section in the full proposal
-        new_section = result["section_markdown"]
-        section_pattern = re.escape(section_heading)
-        updated_md = re.sub(
-            rf"({section_pattern}.*?)(?=\n## |\Z)",
-            new_section + "\n\n",
-            current_md,
-            count=1,
-            flags=re.DOTALL,
-        )
-
-        # Save as new version
-        latest = ProposalVersion.query.filter_by(proposal_id=proposal_id).order_by(
-            ProposalVersion.version_number.desc()
-        ).first()
-        next_version = (latest.version_number + 1) if latest else 1
-
-        version = ProposalVersion(
-            proposal_id=proposal_id,
-            version_number=next_version,
-            markdown_content=updated_md,
-            edit_source="ai",
-            editor_id=current_user.id,
-            change_summary=f"AI regenerated section: {section_heading}",
-        )
-        db.session.add(version)
-
-        # Update file on disk (mirrored to object storage)
-        md_path.write_text(updated_md, encoding="utf-8")
-        storage.sync_up(md_path)
-        if proposal.docx_file:
-            docx_path = GENERATED_DIR / proposal.docx_file
-            _brand_user = project.owner or current_user
-            markdown_to_docx(updated_md, str(docx_path),
-                             **_project_brand_kwargs(project, _brand_user))
-            storage.sync_up(docx_path)
-
-        # Update action items count
-        action_items = re.findall(r"\[ACTION REQUIRED:\s*(.+?)\]", updated_md)
-        proposal.action_items_count = len(action_items)
-
-        db.session.commit()
-        _log_activity("section_regenerate", f"Regenerated section: {section_heading}", project.id)
-        flash(f"Section '{section_heading}' regenerated and saved as v{next_version}.", "success")
-
+    except RuntimeError:
+        raise
     except Exception as e:
-        flash(f"Error regenerating section: {friendly_api_error(e)}", "error")
+        raise RuntimeError(friendly_api_error(e))
 
-    return redirect(url_for("edit_proposal", proposal_id=proposal_id))
+    set_progress("saving", "Saving the new version…")
+    # Replace the section in the full proposal
+    new_section = result["section_markdown"]
+    section_pattern = re.escape(section_heading)
+    updated_md = re.sub(
+        rf"({section_pattern}.*?)(?=\n## |\Z)",
+        new_section + "\n\n",
+        current_md,
+        count=1,
+        flags=re.DOTALL,
+    )
+
+    latest = ProposalVersion.query.filter_by(proposal_id=proposal_id).order_by(
+        ProposalVersion.version_number.desc()
+    ).first()
+    next_version = (latest.version_number + 1) if latest else 1
+    db.session.add(ProposalVersion(
+        proposal_id=proposal_id,
+        version_number=next_version,
+        markdown_content=updated_md,
+        edit_source="ai",
+        editor_id=user.id,
+        change_summary=f"AI regenerated section: {section_heading}",
+    ))
+
+    # Update file on disk (mirrored to object storage)
+    md_path = GENERATED_DIR / proposal.md_file
+    md_path.write_text(updated_md, encoding="utf-8")
+    storage.sync_up(md_path)
+    if proposal.docx_file:
+        docx_path = GENERATED_DIR / proposal.docx_file
+        markdown_to_docx(updated_md, str(docx_path),
+                         **_project_brand_kwargs(project, project.owner or user))
+        storage.sync_up(docx_path)
+
+    proposal.action_items_count = len(
+        re.findall(r"\[ACTION REQUIRED:\s*(.+?)\]", updated_md))
+    db.session.commit()
+    _log_activity_for(user, "section_regenerate",
+                      f"Regenerated section: {section_heading}",
+                      project.id if project else None)
+    return {"redirect": url_for("edit_proposal", proposal_id=proposal_id)}
+
+
+@jobs.register("regenerate_section")
+def _job_regenerate_section(payload, job):
+    user = db.session.get(User, job.user_id)
+    def _sp(phase, message=""):
+        jobs.set_progress(job, phase, message)
+    return _perform_section_regeneration(
+        payload["proposal_id"], user, payload["section_heading"],
+        payload["clarification_answer"], _sp)
 
 
 # ---------------------------------------------------------------------------

--- a/config/settings.py
+++ b/config/settings.py
@@ -44,6 +44,9 @@ DEFAULT_VERTICAL = "general"
 # Anthropic
 ANTHROPIC_API_KEY = os.getenv("ANTHROPIC_API_KEY", "")
 CLAUDE_MODEL = os.getenv("CLAUDE_MODEL", "claude-opus-4-8")
+# Small/fast model for the vertical classifier — it runs inside generation and
+# scope drafting, so latency and cost matter more than depth there.
+CLAUDE_CLASSIFIER_MODEL = os.getenv("CLAUDE_CLASSIFIER_MODEL", "claude-haiku-4-5")
 
 # Database — Postgres in production via DATABASE_URL; SQLite fallback for dev.
 _raw_db_url = os.getenv("DATABASE_URL", "").strip()

--- a/document_parser.py
+++ b/document_parser.py
@@ -79,10 +79,12 @@ def _parse_docx(path: Path) -> str:
 
 
 def detect_vertical(text: str) -> str:
-    """Auto-detect the industry vertical from RFP/RFQ text content.
+    """Keyword-scoring vertical detection — the FALLBACK classifier.
 
-    Returns the vertical key (e.g., 'data_center', 'life_science', etc.).
-    Falls back to 'general' if no strong match is found.
+    proposal_agent.classify_vertical() is the primary path (a fast LLM call);
+    it delegates here when no API key is configured or the call fails, so this
+    must stay dependency-free and never raise. Returns the vertical key
+    (e.g. 'data_center'), or 'general' if no strong match is found.
     """
     text_lower = text.lower()
 

--- a/jobs.py
+++ b/jobs.py
@@ -164,10 +164,23 @@ def reap_stale_jobs():
         logger.warning("Reaped %d stale running job(s)", len(stale))
 
 
+def _job_context():
+    """Execution context for jobs running outside the request cycle.
+
+    A *request* context (not a bare app context): handlers finish by building
+    their redirect with url_for(), which raises outside a request context
+    unless SERVER_NAME is configured — and it isn't. Under a bare app_context
+    every handler would do all its work, commit, then die on the final
+    url_for and mark the job "failed". Inline runs (tests / JOBS_INLINE)
+    execute inside the enqueuing request and never hit this.
+    """
+    return _app.test_request_context()
+
+
 def _worker_loop():
     while True:
         try:
-            with _app.app_context():
+            with _job_context():
                 reap_stale_jobs()
                 job_id = _claim()
                 if job_id:

--- a/proposal_agent.py
+++ b/proposal_agent.py
@@ -21,6 +21,7 @@ import anthropic
 
 from config.settings import (
     ANTHROPIC_API_KEY,
+    CLAUDE_CLASSIFIER_MODEL,
     CLAUDE_MODEL,
     REFERENCE_DIR,
     TEMPLATES_DIR,
@@ -230,6 +231,62 @@ def friendly_api_error(exc: BaseException) -> str:
             f"{getattr(exc, 'message', str(exc))}"
         )
     return str(exc) or exc.__class__.__name__
+
+
+# Only this much RFP text goes to the classifier — the opening pages carry the
+# project identity, and a small excerpt keeps the call fast and cheap.
+CLASSIFIER_MAX_CHARS = 8_000
+
+
+def classify_vertical(text: str, user_api_key: str = None) -> str:
+    """Classify RFP/RFQ text into an industry vertical with a fast LLM call.
+
+    The keyword scorer (document_parser.detect_vertical) misses RFPs that
+    paraphrase — a pharma cleanroom fit-out that never says "GMP" lands in
+    'general' and loses its vertical templates. A small Claude model reads an
+    excerpt instead. The keyword scorer remains the fallback for every failure
+    path (no API key, network/API error, model unavailable, budget exhausted,
+    nonsense answer) so generation never breaks on classification.
+    """
+    from document_parser import detect_vertical
+
+    api_key = user_api_key or ANTHROPIC_API_KEY
+    if not api_key or not (text or "").strip():
+        return detect_vertical(text)
+
+    options = "\n".join(
+        f"- {key}: {cfg.get('description', '')}" for key, cfg in VERTICALS.items()
+    )
+    system_prompt = f"""You classify construction/engineering RFP/RFQ documents into one industry vertical.
+
+Choose exactly one key:
+{options}
+
+Respond with ONLY the key, nothing else (e.g. data_center). Use general when no specific vertical clearly fits."""
+
+    try:
+        client = _make_client(api_key)
+        resp = client.messages.create(
+            model=CLAUDE_CLASSIFIER_MODEL,
+            max_tokens=16,
+            system=system_prompt,
+            messages=[{
+                "role": "user",
+                "content": f"---BEGIN RFP EXCERPT---\n{text[:CLASSIFIER_MAX_CHARS]}\n---END---",
+            }],
+        )
+        answer = "".join(
+            b.text for b in resp.content if getattr(b, "type", "") == "text"
+        )
+        # Tolerate quoting/punctuation around the key ('"Data_Center".' etc.)
+        answer = re.sub(r"[^a-z_]", "", answer.strip().lower())
+        if answer in VERTICALS:
+            return answer
+    except Exception:
+        # Includes AiBudgetExceeded on purpose: the main generation call runs
+        # its own budget check and surfaces that error where the user sees it.
+        pass
+    return detect_vertical(text)
 
 
 def _build_system_prompt(vertical_key: str, vertical_resources: dict,
@@ -580,8 +637,7 @@ def draft_scope_of_work(rfp_text: str, vertical: str = "auto",
         )
 
     if vertical == "auto":
-        from document_parser import detect_vertical
-        vertical = detect_vertical(rfp_text)
+        vertical = classify_vertical(rfp_text, user_api_key=user_api_key)
     vertical_label = VERTICALS.get(vertical, {}).get("label", "General")
 
     company_line = f"You are working on behalf of **{company_name}**.\n" if company_name else ""
@@ -719,9 +775,8 @@ def generate_proposal(rfp_text: str, vertical: str = "auto",
 
     # Resolve vertical
     if vertical == "auto":
-        from document_parser import detect_vertical
         _report("detection", "Analyzing document to detect industry vertical...")
-        vertical = detect_vertical(rfp_text)
+        vertical = classify_vertical(rfp_text, user_api_key=user_api_key)
 
     vertical_label = VERTICALS.get(vertical, {}).get("label", "General")
     _report("init", f"Loading {vertical_label} templates and reference documents...")

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -34,7 +34,7 @@
     --mist-deep: #e7f0ec;
 
     /* -- Status hues -- */
-    --gold:      #a16207;
+    --gold:      #8f5808;
     --gold-bg:   #fdf3dd;
     --gold-line: #f0dcae;
     --red:       #b3362a;
@@ -1193,7 +1193,7 @@ body {
 .footer {
     text-align: center;
     padding: 26px 20px;
-    color: var(--ink-300);
+    color: var(--ink-500);
     font-size: 12.5px;
 }
 
@@ -1293,7 +1293,7 @@ body {
 .setup-banner-close {
     background: none;
     border: none;
-    color: var(--ink-300);
+    color: var(--ink-500);
     font-size: 20px;
     cursor: pointer;
     padding: 4px 8px;
@@ -1488,7 +1488,7 @@ body {
     font-size: 12px;
     color: var(--ink-500);
 }
-.focus-item-meta .mono { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 11.5px; color: var(--ink-300); letter-spacing: 0.03em; }
+.focus-item-meta .mono { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 11.5px; color: var(--ink-500); letter-spacing: 0.03em; }
 .focus-item-sub { font-size: 12.5px; margin-top: 3px; color: var(--ink-500); }
 .focus-item-sub .focus-overdue { color: var(--red); font-weight: 600; }
 .focus-item-side { display: flex; align-items: center; gap: 10px; flex-shrink: 0; }
@@ -1694,7 +1694,7 @@ body {
     color: var(--white);
 }
 .step.step-lost { background: var(--red-bg); color: var(--red); }
-.step.step-pending { background: var(--mist); color: var(--ink-300); }
+.step.step-pending { background: var(--mist); color: var(--ink-500); }
 .stepper-progress {
     display: flex;
     align-items: center;
@@ -1813,7 +1813,7 @@ body {
     box-shadow: 0 0 0 1.5px var(--sea-200);
 }
 .timeline .tl-title { font-weight: 600; color: var(--ink-900); }
-.timeline .tl-meta { font-size: 11.5px; color: var(--ink-300); }
+.timeline .tl-meta { font-size: 11.5px; color: var(--ink-500); }
 .timeline .tl-note { font-size: 12px; color: var(--ink-500); font-style: italic; }
 
 /* Document viewer card */
@@ -2992,6 +2992,42 @@ body {
 /* ============================================================
    Responsive
    ============================================================ */
+
+/* Horizontal-scroll container for wide tables: the table scrolls inside its
+   card, the page body never scrolls sideways. */
+.table-scroll {
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    max-width: 100%;
+}
+.table-scroll > table { margin-top: 0; }
+
+/* Tablet: the fixed sidebar becomes an off-canvas drawer. The existing
+   desktop collapse (icon rail) stops applying — the toggle opens/closes the
+   drawer instead (see the sidebar-toggle script in base.html). */
+@media (max-width: 1024px) {
+    .sidebar {
+        transform: translateX(-100%);
+        transition: transform 0.2s ease;
+        width: var(--sidebar-width);
+        box-shadow: none;
+    }
+    .sidebar.collapsed { width: var(--sidebar-width); }
+    .sidebar.mobile-open {
+        transform: translateX(0);
+        box-shadow: var(--shadow-lg);
+    }
+    .main-wrapper,
+    .main-wrapper.sidebar-collapsed { margin-left: 0; }
+    .sidebar-backdrop {
+        position: fixed;
+        inset: 0;
+        background: rgba(7, 51, 45, 0.45);
+        z-index: 190;
+    }
+    .sidebar-backdrop[hidden] { display: none; }
+}
+
 @media (max-width: 860px) {
     .main-content { padding: 0 16px; }
     .topbar { padding: 10px 14px; gap: 10px; }
@@ -2999,6 +3035,34 @@ body {
     .topbar-user { display: none; }
     .greeting { font-size: 26px; }
     .viewer-body, .proposal-content { padding: 22px 18px; }
+    .topbar-search .kbd-hint { display: none; }
+    /* Flex children need min-width: 0 to shrink below their content size —
+       without it the search input + avatar chip push the topbar (and the
+       whole page) wider than the viewport. */
+    .topbar-search { max-width: none; min-width: 0; }
+    .topbar-search input { width: 100%; min-width: 0; }
+    .avatar-name, .avatar-caret { display: none; }
+    .topbar-right { gap: 4px; }
+    .page-header-row { flex-wrap: wrap; gap: 10px; }
+    .form-actions { flex-wrap: wrap; }
+    .card { padding: 16px 14px; }
+    /* 16px inputs stop iOS Safari from auto-zooming the page on focus */
+    input[type="text"], input[type="email"], input[type="password"],
+    input[type="number"], input[type="search"], input[type="url"],
+    select, textarea { font-size: 16px; }
+    /* Safety net for wide tables that aren't wrapped in .table-scroll:
+       scroll within their own box instead of stretching the page. */
+    .proposals-table, .mini-table {
+        display: block;
+        overflow-x: auto;
+        -webkit-overflow-scrolling: touch;
+    }
+    /* The 6-month trend chart keeps readable bars and scrolls in its card */
+    .trend-chart { overflow-x: auto; gap: 12px; }
+    .trend-col { min-width: 44px; }
+    /* Month calendar: keep day cells usable and scroll sideways in its card */
+    .calendar-grid { min-width: 640px; }
+    .activity-filter { flex-wrap: wrap; }
 }
 
 @media print {

--- a/test_ai_jobs.py
+++ b/test_ai_jobs.py
@@ -1,0 +1,355 @@
+"""Regression tests for jobifying the last inline AI calls.
+
+Addendum impact analysis, targeted section regeneration, and the posture
+"AI import & review" flows (rates + standards) previously ran their AI calls
+in the request path — minutes-long calls holding a gunicorn worker. They now
+enqueue background jobs (progress page + cancel, like generation), carry the
+platform-AI verified-email gate, parse documents with ocr=True (OCR is
+allowed inside jobs), and the ingest review screen reads its rows from the
+finished job's result.
+
+Also covers two fixes landed alongside:
+  - the job runner executes handlers in a *request* context so the final
+    url_for-built redirect works in production workers (no SERVER_NAME is
+    configured, so a bare app context would fail every job at the finish line);
+  - the addendum route rejects document ids belonging to another project
+    (previously any doc id parsed into the analysis).
+
+Standalone runner: python test_ai_jobs.py
+"""
+import io
+import os
+import sys
+from unittest.mock import patch
+
+os.environ['FLASK_SECRET_KEY'] = 'test-secret-key-12345'
+os.environ.pop('APP_ENV', None)
+
+import app as appmod
+from app import app, db
+import jobs
+from config.settings import GENERATED_DIR
+from models import (BackgroundJob, ClarificationItem, CompanyStandard, Project,
+                    ProjectDocument, Proposal, ProposalVersion, StaffRole, User)
+
+app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+app.config['TESTING'] = True
+
+passed = failed = 0
+
+
+def test(name, cond, detail=""):
+    global passed, failed
+    if cond:
+        passed += 1; print(f"  PASS: {name}")
+    else:
+        failed += 1; print(f"  FAIL: {name} - {detail}")
+
+
+PROPOSAL_MD = ("# Proposal V1MARKER\n\n"
+               "## Scope of Work\n\nOld scope line\n\n"
+               "## Pricing\n\nOld pricing line\n\n"
+               "Confidence Score: 80%")
+
+
+def fake_generate(rfp_text, **kwargs):
+    return {"proposal_markdown": PROPOSAL_MD,
+            "action_items": [], "confidence_score": 80, "document_type": "RFP",
+            "vertical": kwargs.get("vertical") or "general",
+            "vertical_label": "General",
+            "generated_at": "2026-01-01T00:00:00+00:00"}
+
+
+def job_of(kind):
+    return (BackgroundJob.query.filter_by(kind=kind)
+            .order_by(BackgroundJob.created_at.desc()).first())
+
+
+def job_count(kind):
+    return BackgroundJob.query.filter_by(kind=kind).count()
+
+
+with app.app_context():
+    db.drop_all(); db.create_all()
+    c = app.test_client()
+    c.post('/signup', data={'username': 'zoe', 'email': 'zoe@corp.com',
+                            'password': 'password123', 'display_name': 'Zoe',
+                            'company_name': 'ZoeCorp'})
+    zoe = User.query.filter_by(username='zoe').first()
+    zoe.email_verified = True
+    db.session.commit()
+
+    c.post('/projects/new', data={'project_name': 'JobsBid', 'client_name': 'Acme'})
+    proj = Project.query.filter_by(name='JobsBid').first()
+    c.post(f'/projects/{proj.id}/upload', data={
+        'file_type': 'rfp',
+        'documents': (io.BytesIO(b'RFP: build a control system for Acme'), 'rfp.txt'),
+    }, content_type='multipart/form-data')
+    with patch('app.generate_proposal', side_effect=fake_generate):
+        c.post(f'/projects/{proj.id}/generate',
+               data={'vertical': 'general', 'output_format': 'docx'})
+    prop = Proposal.query.filter_by(project_id=proj.id).first()
+    base_versions = ProposalVersion.query.filter_by(proposal_id=prop.id).count()
+
+    print("\n=== Addendum analysis runs as a background job ===")
+    c.post(f'/projects/{proj.id}/upload', data={
+        'file_type': 'rfp',
+        'documents': (io.BytesIO(b'Addendum 1: voltage changed to 480V'), 'addendum.txt'),
+    }, content_type='multipart/form-data')
+    addendum_doc = (ProjectDocument.query.filter_by(project_id=proj.id)
+                    .filter(ProjectDocument.original_filename == 'addendum.txt').first())
+    test("addendum doc uploaded", addendum_doc is not None)
+
+    parse_calls = []
+    real_parse = appmod.parse_document
+    def spy_parse(path, **kw):
+        parse_calls.append(kw)
+        return real_parse(path, **kw)
+
+    def fake_addendum(rfp_text, addendum_text, current_md, **kwargs):
+        assert 'voltage changed' in addendum_text
+        return {"changes": [
+            {"addendum_item": "Voltage now 480V", "severity": "high",
+             "impact_description": "Electrical scope changes",
+             "suggested_resolution": "Update the scope section",
+             "affected_sections": ["Scope of Work", "Pricing"],
+             "can_ai_resolve": True},
+            {"addendum_item": "Deadline moved up", "severity": "medium",
+             "impact_description": "Schedule impact",
+             "suggested_resolution": "Revise timeline",
+             "affected_sections": ["Schedule"], "can_ai_resolve": False},
+        ]}
+
+    with patch('app.analyze_addendum_impact', side_effect=fake_addendum), \
+         patch('app.parse_document', side_effect=spy_parse):
+        r = c.post(f'/projects/{proj.id}/addendum-analysis',
+                   data={'addendum_doc_id': addendum_doc.id})
+    test("route redirects to the job progress page",
+         r.status_code == 302 and '/jobs/' in r.headers['Location'],
+         r.headers.get('Location', ''))
+    job = job_of('analyze_addendum')
+    test("addendum job ran to done", job is not None and job.status == 'done',
+         f"{job and job.status}: {job and job.error}")
+    test("documents parsed with OCR allowed",
+         parse_calls and all(kw.get('ocr') is True for kw in parse_calls),
+         str(parse_calls))
+    items = ClarificationItem.query.filter_by(project_id=proj.id, source='addendum').all()
+    test("two impacts filed in the clarification register", len(items) == 2)
+    hi = next((i for i in items if i.priority == 'high'), None)
+    test("impact fields recorded", hi is not None
+         and hi.question == 'Voltage now 480V'
+         and hi.proposal_section == 'Scope of Work, Pricing'
+         and hi.created_by == zoe.id and hi.status == 'open')
+    db.session.refresh(proj)
+    test("project flagged clarification_pending",
+         proj.clarification_sub_status == 'clarification_pending')
+    r = c.get(f'/jobs/{job.id}/status.json')
+    test("job redirect points at the clarification register",
+         r.get_json().get('redirect', '').endswith(f'/projects/{proj.id}/clarifications'))
+    r = c.get(f'/jobs/{job.id}')
+    test("progress page labels the job kind", b'Analyzing addendum' in r.data)
+
+    print("\n=== Addendum guards ===")
+    c.post('/projects/new', data={'project_name': 'OtherBid', 'client_name': 'B'})
+    projB = Project.query.filter_by(name='OtherBid').first()
+    c.post(f'/projects/{projB.id}/upload', data={
+        'file_type': 'rfp',
+        'documents': (io.BytesIO(b'Some other RFP'), 'other.txt'),
+    }, content_type='multipart/form-data')
+    docB = ProjectDocument.query.filter_by(project_id=projB.id).first()
+
+    n = job_count('analyze_addendum')
+    r = c.post(f'/projects/{proj.id}/addendum-analysis',
+               data={'addendum_doc_id': docB.id}, follow_redirects=True)
+    test("doc from another project is rejected",
+         b'Addendum document not found' in r.data and job_count('analyze_addendum') == n)
+
+    r = c.post(f'/projects/{projB.id}/addendum-analysis',
+               data={'addendum_doc_id': docB.id}, follow_redirects=True)
+    test("no proposal yet -> friendly error, no job",
+         b'No existing proposal' in r.data and job_count('analyze_addendum') == n)
+
+    zoe.email_verified = False
+    db.session.commit()
+    r = c.post(f'/projects/{proj.id}/addendum-analysis',
+               data={'addendum_doc_id': addendum_doc.id}, follow_redirects=True)
+    test("unverified email is gated from platform AI",
+         b'verify your email' in r.data and job_count('analyze_addendum') == n)
+    zoe.email_verified = True
+    db.session.commit()
+
+    with patch('app.analyze_addendum_impact', side_effect=Exception('kaboom')):
+        c.post(f'/projects/{proj.id}/addendum-analysis',
+               data={'addendum_doc_id': addendum_doc.id})
+    job = job_of('analyze_addendum')
+    test("AI failure marks the job failed with the message",
+         job.status == 'failed' and 'kaboom' in (job.error or ''),
+         f"{job.status}: {job.error}")
+    test("failed analysis files no impacts",
+         ClarificationItem.query.filter_by(project_id=proj.id, source='addendum').count() == 2)
+
+    print("\n=== Section regeneration runs as a background job ===")
+    def fake_regen(**kwargs):
+        assert kwargs['section_heading'] == '## Scope of Work'
+        assert 'Old scope line' in kwargs['full_proposal_md']
+        return {"section_markdown": "## Scope of Work\n\nNEW REGEN CONTENT "
+                                    "[ACTION REQUIRED: confirm voltage]"}
+
+    with patch('app.regenerate_section', side_effect=fake_regen):
+        r = c.post(f'/proposal/{prop.id}/regenerate-section',
+                   data={'section_heading': '## Scope of Work',
+                         'clarification_answer': 'Voltage is 480V'})
+    test("route redirects to the job progress page",
+         r.status_code == 302 and '/jobs/' in r.headers['Location'])
+    job = job_of('regenerate_section')
+    test("regeneration job ran to done", job is not None and job.status == 'done',
+         f"{job and job.status}: {job and job.error}")
+    versions = (ProposalVersion.query.filter_by(proposal_id=prop.id)
+                .order_by(ProposalVersion.version_number.desc()).all())
+    test("a new version was saved", len(versions) == base_versions + 1)
+    test("only the target section was replaced",
+         'NEW REGEN CONTENT' in versions[0].markdown_content
+         and 'Old pricing line' in versions[0].markdown_content
+         and 'Old scope line' not in versions[0].markdown_content)
+    test("version credited to the requesting user (ai edit)",
+         versions[0].edit_source == 'ai' and versions[0].editor_id == zoe.id)
+    db.session.refresh(prop)
+    test("action items recounted from the new content", prop.action_items_count == 1)
+    md_on_disk = (GENERATED_DIR / prop.md_file).read_text(encoding='utf-8')
+    test("markdown artifact mirrors the new version", 'NEW REGEN CONTENT' in md_on_disk)
+    r = c.get(f'/jobs/{job.id}/status.json')
+    test("job redirect returns to the editor",
+         r.get_json().get('redirect', '').endswith(f'/proposal/{prop.id}/edit'))
+
+    print("\n=== Section regeneration guards ===")
+    n = job_count('regenerate_section')
+    r = c.post(f'/proposal/{prop.id}/regenerate-section',
+               data={'section_heading': '## Not A Real Section',
+                     'clarification_answer': 'info'}, follow_redirects=True)
+    test("unknown heading fails fast without a job",
+         b'Couldn&#39;t find' in r.data and job_count('regenerate_section') == n,
+         r.data[:200])
+    r = c.post(f'/proposal/{prop.id}/regenerate-section',
+               data={'section_heading': '', 'clarification_answer': 'x'},
+               follow_redirects=True)
+    test("missing fields fail fast without a job",
+         b'required' in r.data and job_count('regenerate_section') == n)
+
+    print("\n=== Rates ingest runs as a background job ===")
+    def fake_rates(raw_text, target, **kwargs):
+        assert 'PM,100' in raw_text
+        return [{"role_name": "PM", "category": "Management",
+                 "hourly_rate": 100, "overtime_rate": 150},
+                {"role_name": "Tech", "category": "Field",
+                 "hourly_rate": 80, "overtime_rate": 120}]
+
+    with patch('app.extract_rates_from_sheet', side_effect=fake_rates):
+        r = c.post('/posture/ingest-rates', data={
+            'target_type': 'labor_rates',
+            'ingest_file': (io.BytesIO(b'Role,Rate\nPM,100\nTech,80'), 'rates.csv'),
+        }, content_type='multipart/form-data')
+    test("route redirects to the job progress page",
+         r.status_code == 302 and '/jobs/' in r.headers['Location'])
+    job = job_of('ingest_rates')
+    test("rates job ran to done", job is not None and job.status == 'done',
+         f"{job and job.status}: {job and job.error}")
+    r = c.get(f'/jobs/{job.id}/status.json')
+    review_url = r.get_json().get('redirect', '')
+    test("job redirect points at the review screen",
+         review_url.endswith(f'/posture/ingest-review/{job.id}'), review_url)
+    r = c.get(review_url)
+    test("review screen renders the extracted rows",
+         r.status_code == 200 and b'value="PM"' in r.data and b'value="Tech"' in r.data
+         and b'rates.csv' in r.data)
+
+    c.post('/posture/ingest-rates/confirm', data={
+        'target_type': 'labor_rates',
+        'row_marker': ['0', '1'], 'include': ['0'],
+        'role_name': ['PM', 'Tech'], 'category': ['Management', 'Field'],
+        'hourly_rate': ['100', '80'], 'overtime_rate': ['150', '120'],
+    })
+    test("confirm import still writes the kept rows",
+         StaffRole.query.filter_by(org_id=zoe.org_id, role_name='PM').count() == 1
+         and StaffRole.query.filter_by(org_id=zoe.org_id, role_name='Tech').count() == 0)
+
+    with patch('app.extract_rates_from_sheet', return_value=[]):
+        c.post('/posture/ingest-rates', data={
+            'target_type': 'labor_rates',
+            'ingest_file': (io.BytesIO(b'nothing useful'), 'empty.csv'),
+        }, content_type='multipart/form-data')
+    job = job_of('ingest_rates')
+    test("zero extracted rows fails the job with guidance",
+         job.status == 'failed' and 'any rows' in (job.error or ''))
+
+    print("\n=== Standards ingest runs as a background job ===")
+    def fake_standards(text, **kwargs):
+        assert 'Always torque-check' in text
+        return [{"category": "qa", "title": "Torque Standard",
+                 "content": "Always torque-check terminations."}]
+
+    with patch('app.extract_standards', side_effect=fake_standards):
+        r = c.post('/posture/ingest-standards', data={
+            'standards_file': (io.BytesIO(b'Always torque-check terminations.'),
+                               'standards.txt'),
+        }, content_type='multipart/form-data')
+    job = job_of('ingest_standards')
+    test("standards job ran to done", job is not None and job.status == 'done',
+         f"{job and job.status}: {job and job.error}")
+    r = c.get(f'/posture/ingest-review/{job.id}')
+    test("review screen renders the extracted blocks",
+         r.status_code == 200 and b'Torque Standard' in r.data)
+    c.post('/posture/ingest-standards/confirm', data={
+        'include': ['0'], 'category': ['qa'], 'title': ['Torque Standard'],
+        'content': ['Always torque-check terminations.'],
+    })
+    test("confirm import writes the standard",
+         CompanyStandard.query.filter_by(org_id=zoe.org_id,
+                                         title='Torque Standard').count() == 1)
+    rates_job_id = job_of('ingest_rates').id
+
+    print("\n=== Review screen access control ===")
+    r = c.get(f'/posture/ingest-review/{prop.id}')
+    test("non-job id 404s", r.status_code == 404)
+    gen_job = job_of('generate_proposal')
+    r = c.get(f'/posture/ingest-review/{gen_job.id}')
+    test("non-ingest job kinds 404", r.status_code == 404)
+
+    c.post('/logout')
+    c.post('/signup', data={'username': 'rival', 'email': 'rival@other.com',
+                            'password': 'password123', 'company_name': 'OtherCo'})
+    r = c.get(f'/posture/ingest-review/{rates_job_id}')
+    test("another user's review screen 404s", r.status_code == 404)
+
+    n = job_count('ingest_rates')
+    r = c.post('/posture/ingest-rates', data={
+        'target_type': 'labor_rates',
+        'ingest_file': (io.BytesIO(b'Role,Rate\nX,1'), 'r.csv'),
+    }, content_type='multipart/form-data', follow_redirects=True)
+    test("unverified email is gated from rates ingest",
+         b'verify your email' in r.data and job_count('ingest_rates') == n)
+    n = job_count('ingest_standards')
+    r = c.post('/posture/ingest-standards', data={
+        'standards_file': (io.BytesIO(b'std'), 's.txt'),
+    }, content_type='multipart/form-data', follow_redirects=True)
+    test("unverified email is gated from standards ingest",
+         b'verify your email' in r.data and job_count('ingest_standards') == n)
+
+    print("\n=== Worker context: url_for works outside a request ===")
+    @jobs.register("ctx_url_probe")
+    def _probe(payload, j):
+        from flask import url_for
+        return {"redirect": url_for("dashboard")}
+
+    probe = BackgroundJob(kind='ctx_url_probe', user_id=zoe.id, org_id=zoe.org_id,
+                          status='queued', payload='{}')
+    db.session.add(probe); db.session.commit()
+    with jobs._job_context():
+        jobs._run_job(probe.id)
+    db.session.refresh(probe)
+    test("handler builds its redirect in the worker context",
+         probe.status == 'done' and 'redirect' in (probe.result or ''),
+         f"{probe.status}: {probe.error}")
+
+print("\n" + "=" * 50)
+print(f"Results: {passed} passed, {failed} failed out of {passed + failed} tests")
+sys.exit(0 if failed == 0 else 1)

--- a/test_reports.py
+++ b/test_reports.py
@@ -1,0 +1,180 @@
+"""Regression tests for the SQL-aggregated /reports page.
+
+/reports previously loaded every accessible project into Python and bucketed
+there — linear cost per request. Every section now aggregates in SQL
+(grouped counts/sums, SQL-side caps). These tests pin the numbers each
+section renders, the access scoping (admin = org-wide, member = own +
+assigned, never cross-org), the 6-month trend window, and the
+missing-close-details selection.
+
+Standalone runner: python test_reports.py
+"""
+import os
+import sys
+from datetime import datetime, timezone
+
+os.environ['FLASK_SECRET_KEY'] = 'test-secret-key-12345'
+os.environ.pop('APP_ENV', None)
+
+from app import app, db
+from models import Organization, Project, User
+
+app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+app.config['TESTING'] = True
+
+passed = failed = 0
+
+
+def test(name, cond, detail=""):
+    global passed, failed
+    if cond:
+        passed += 1; print(f"  PASS: {name}")
+    else:
+        failed += 1; print(f"  FAIL: {name} - {detail}")
+
+
+def month_shift(base, months_back, day=15):
+    m = base.month - months_back
+    y = base.year
+    while m <= 0:
+        m += 12
+        y -= 1
+    return datetime(y, m, day)
+
+
+with app.app_context():
+    from flask import g
+
+    def _fresh_request_state():
+        # These suites run inside ONE long-lived app context, so flask-login's
+        # per-context user cache (g._login_user) survives across simulated
+        # requests. Clearing it between interleaved clients reproduces
+        # production's fresh-context-per-request behavior.
+        if hasattr(g, '_login_user'):
+            delattr(g, '_login_user')
+
+    db.drop_all(); db.create_all()
+    c = app.test_client()
+    c.post('/signup', data={'username': 'zoe', 'email': 'zoe@corp.com',
+                            'password': 'password123', 'company_name': 'ZoeCorp'})
+    zoe = User.query.filter_by(username='zoe').first()
+    zoe.email_verified = True
+    sam = User(username='sam', email='sam@corp.com', org_id=zoe.org_id, role='sales')
+    sam.set_password('password123')
+    db.session.add(sam)
+    db.session.commit()
+
+    now = datetime.now(timezone.utc).replace(tzinfo=None)
+    this_month = month_shift(now, 0)
+    prev_month = month_shift(now, 1)
+    long_ago = month_shift(now, 8)
+
+    DC = 'Data Center / Mission Critical'
+
+    def proj(name, owner, **kw):
+        p = Project(name=name, client_name='Acme', user_id=owner.id,
+                    org_id=owner.org_id, **kw)
+        db.session.add(p)
+        return p
+
+    # Zoe's org fixture (7 projects)
+    proj('WonBig', zoe, status='won', dollar_amount=100000.0, vertical_label=DC,
+         close_category='price', competitor_name='Rival Corp', closed_at=this_month)
+    proj('WonSmall', zoe, status='won', dollar_amount=50000.0, vertical_label=DC,
+         close_category='relationship', closed_at=this_month)
+    proj('LostOne', zoe, status='lost', dollar_amount=30000.0, vertical_label='General',
+         competitor_name='Rival Corp', closed_at=prev_month)
+    proj('ActiveOne', zoe, status='active', vertical_label='General')
+    proj('SubmittedOne', zoe, status='submitted', vertical_label='')
+    proj('GhostClose', zoe, status='lost', dollar_amount=10000.0,
+         closed_at=long_ago)  # no close details at all; outside trend window
+    proj('SamWin', sam, status='won', dollar_amount=20000.0, vertical_label='General',
+         close_category='price', closed_at=this_month)
+
+    # A different org that must never leak into ZoeCorp's reports
+    c2 = app.test_client()
+    c2.post('/signup', data={'username': 'other', 'email': 'other@elsewhere.com',
+                             'password': 'password123', 'company_name': 'ElseCo'})
+    other = User.query.filter_by(username='other').first()
+    proj('GhostBid', other, status='won', dollar_amount=999999.0,
+         vertical_label=DC, closed_at=this_month)
+    db.session.commit()
+
+    print("\n=== Admin view: org-wide aggregates ===")
+    _fresh_request_state()
+    c.post('/login', data={'username': 'zoe', 'password': 'password123'})
+    _fresh_request_state()
+    r = c.get('/reports')
+    html = r.data.decode()
+    test("page renders", r.status_code == 200)
+    test("overall win rate 3/5 decided = 60%", '60%' in html)
+    test("won/lost counts", '3 / 2' in html)
+    test("revenue won $170,000", '$170,000' in html)
+    test("revenue lost $40,000", '$40,000' in html)
+    test("total projects = 7", '<span class="stat-number">7</span>' in html)
+    test("active pipeline = 1", '<span class="stat-number">1</span>' in html)
+
+    test("vertical rows present", DC in html and 'General' in html)
+    test("DC win rate 100%", '100%' in html)
+    # Vertical table is ordered by closed value: DC ($150k) before General ($60k)
+    test("verticals ordered by book of business",
+         html.index(DC) < html.index('<span class="badge badge-vertical">General</span>'),
+         "DC should render before General")
+
+    test("competitor table shows Rival Corp", 'Rival Corp' in html)
+    test("competitor win rate 1 of 2 = 50%", '50%' in html)
+
+    test("won reasons: Price counted",
+         'Price' in html and '<span class="reason-count">1</span>' in html)
+    test("lost reasons: blanks land in Other",
+         'Other' in html and '<span class="reason-count">2</span>' in html)
+
+    test("trend: current month has 3 wins", 'title="Won: 3' in html)
+    test("trend: previous month has 1 loss", 'title="Lost: 1' in html)
+    test("trend: 8-month-old closure outside the window",
+         'title="Won: 4' not in html and 'title="Lost: 2' not in html)
+
+    test("missing-details lists the detail-less closure", 'GhostClose' in html)
+    test("closures with any detail are not nagged",
+         'WonSmall' not in html.split('Fill in Missing Close Details')[-1])
+
+    print("\n=== Cross-org isolation ===")
+    test("other org's project name absent", 'GhostBid' not in html)
+    test("other org's value absent", '999,999' not in html)
+
+    print("\n=== Member view: own + assigned only ===")
+    c.post('/logout')
+    _fresh_request_state()
+    c.post('/login', data={'username': 'sam', 'password': 'password123'})
+    _fresh_request_state()
+    r = c.get('/reports')
+    html = r.data.decode()
+    test("member sees only their own project",
+         '<span class="stat-number">1</span>' in html and 'SamWin' not in html
+         and '$20,000' in html and '1 / 0' in html)
+    test("member does not see org-mates' totals", '$170,000' not in html)
+
+    # Assignment pulls a project into the member's report
+    lost = Project.query.filter_by(name='LostOne').first()
+    lost.assigned_to = sam.id
+    db.session.commit()
+    _fresh_request_state()
+    r = c.get('/reports')
+    html = r.data.decode()
+    test("assigned project joins the member's numbers",
+         '1 / 1' in html and '$30,000' in html)
+
+    print("\n=== Empty state ===")
+    c3 = app.test_client()
+    _fresh_request_state()
+    c3.post('/signup', data={'username': 'newbie', 'email': 'new@fresh.com',
+                             'password': 'password123', 'company_name': 'FreshCo'})
+    _fresh_request_state()
+    r = c3.get('/reports')
+    html = r.data.decode()
+    test("fresh org renders zeros without errors",
+         r.status_code == 200 and '0%' in html and 'No projects yet' in html)
+
+print("\n" + "=" * 50)
+print(f"Results: {passed} passed, {failed} failed out of {passed + failed} tests")
+sys.exit(0 if failed == 0 else 1)

--- a/test_reset_throttle.py
+++ b/test_reset_throttle.py
@@ -1,0 +1,120 @@
+"""Regression tests for the /forgot-password throttle.
+
+The endpoint is unauthenticated and sends email, so before the throttle an
+attacker could bomb a victim's inbox with reset mail (or drain the SMTP
+budget) with a trivial loop. Requests are now limited per requesting IP and
+per target email on a sliding window; throttled requests return the exact
+same generic response so a prober learns nothing — the observable effect is
+that no reset token is issued and no email is sent.
+
+Standalone runner: python test_reset_throttle.py
+"""
+import os
+import re
+import sys
+import time
+
+os.environ['FLASK_SECRET_KEY'] = 'test-secret-key-12345'
+os.environ.pop('APP_ENV', None)
+
+import app as appmod
+from app import app, db
+from models import User, UserToken
+
+app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+app.config['TESTING'] = True
+
+passed = failed = 0
+
+
+def test(name, cond, detail=""):
+    global passed, failed
+    if cond:
+        passed += 1; print(f"  PASS: {name}")
+    else:
+        failed += 1; print(f"  FAIL: {name} - {detail}")
+
+
+print("\n=== Sliding-window helper ===")
+appmod._RESET_REQUESTS.clear()
+for _ in range(appmod._RESET_MAX_PER_WINDOW):
+    test_limited_before = appmod._reset_rate_limited("k")
+    appmod._record_reset_request("k")
+test("under the limit is allowed", test_limited_before is False)
+test("at the limit is blocked", appmod._reset_rate_limited("k") is True)
+appmod._RESET_REQUESTS["k"] = [time.time() - appmod._RESET_WINDOW_SECONDS - 1] * 10
+test("old attempts age out of the window", appmod._reset_rate_limited("k") is False)
+appmod._RESET_REQUESTS.clear()
+
+with app.app_context():
+    db.drop_all(); db.create_all()
+    c = app.test_client()
+    c.post('/signup', data={'username': 'tara', 'email': 'tara@corp.com',
+                            'password': 'password123', 'company_name': 'TaraCo'})
+    c.post('/signup', data={'username': 'omar', 'email': 'omar@corp.com',
+                            'password': 'password123', 'company_name': 'OmarCo'})
+    tara = User.query.filter_by(username='tara').first()
+    omar = User.query.filter_by(username='omar').first()
+
+    def reset_tokens(user):
+        return UserToken.query.filter_by(user_id=user.id, purpose='reset').count()
+
+    print("\n=== Throttle enforced on the live route (TESTING off) ===")
+    # The gate is skipped under TESTING (like the signup throttle), so flip it
+    # off and drive the real production path, CSRF included.
+    app.config['TESTING'] = False
+    appmod._RESET_REQUESTS.clear()
+    try:
+        anon = app.test_client()
+        html = anon.get('/forgot-password').data.decode()
+        tok = re.search(r'name="csrf_token" value="([^"]+)"', html).group(1)
+        test("forgot-password form carries a CSRF token", bool(tok))
+
+        for i in range(7):
+            r = anon.post('/forgot-password',
+                          data={'email': 'tara@corp.com', 'csrf_token': tok})
+        test("responses stay identical after the limit (no probe signal)",
+             r.status_code == 302)
+        test("only the first 5 requests issued tokens",
+             reset_tokens(tara) == appmod._RESET_MAX_PER_WINDOW,
+             f"tokens={reset_tokens(tara)}")
+
+        # The same IP is now exhausted — a different target email is blocked
+        # too, so one client can't rotate through victims.
+        anon.post('/forgot-password',
+                  data={'email': 'omar@corp.com', 'csrf_token': tok})
+        test("exhausted IP can't switch to another victim",
+             reset_tokens(omar) == 0, f"tokens={reset_tokens(omar)}")
+
+        # A different IP hammering the SAME inbox trips the per-email key.
+        appmod._RESET_REQUESTS.pop("ip:127.0.0.1", None)
+        anon.post('/forgot-password',
+                  data={'email': 'tara@corp.com', 'csrf_token': tok})
+        test("fresh IP still can't bomb an exhausted inbox",
+             reset_tokens(tara) == appmod._RESET_MAX_PER_WINDOW,
+             f"tokens={reset_tokens(tara)}")
+
+        # Window expiry frees the flow again.
+        for key in list(appmod._RESET_REQUESTS):
+            appmod._RESET_REQUESTS[key] = [
+                t - appmod._RESET_WINDOW_SECONDS - 1 for t in appmod._RESET_REQUESTS[key]
+            ]
+        anon.post('/forgot-password',
+                  data={'email': 'tara@corp.com', 'csrf_token': tok})
+        test("throttle releases after the window",
+             reset_tokens(tara) == appmod._RESET_MAX_PER_WINDOW + 1,
+             f"tokens={reset_tokens(tara)}")
+    finally:
+        app.config['TESTING'] = True
+        appmod._RESET_REQUESTS.clear()
+
+    print("\n=== Reset flow still works end to end ===")
+    raw = appmod._issue_token(tara, 'reset', hours=2)
+    r = c.post(f'/reset-password/{raw}',
+               data={'password': 'newpassword99', 'confirm_password': 'newpassword99'})
+    db.session.refresh(tara)
+    test("valid token still resets the password", tara.check_password('newpassword99'))
+
+print("\n" + "=" * 50)
+print(f"Results: {passed} passed, {failed} failed out of {passed + failed} tests")
+sys.exit(0 if failed == 0 else 1)

--- a/test_responsive_a11y.py
+++ b/test_responsive_a11y.py
@@ -1,0 +1,183 @@
+"""Regression tests for the mobile-responsive sweep + WCAG AA pass.
+
+Pins: the off-canvas sidebar breakpoint and backdrop, the .table-scroll
+wrappers on wide tables (and the ≤860px safety net for unwrapped ones), the
+iOS no-zoom input sizing, palette contrast ratios computed with the real
+WCAG formula (so a future color tweak that breaks AA fails loudly), the
+ink-300 text retargeting, and the ARIA wiring (sidebar toggle state, search /
+chatbot / ingest-review / reports-inline form labels). Also compiles every
+template touched by the sweep so a malformed wrapper can't ship.
+
+Standalone runner: python test_responsive_a11y.py
+"""
+import os
+import re
+import sys
+from datetime import datetime, timezone
+
+os.environ['FLASK_SECRET_KEY'] = 'test-secret-key-12345'
+os.environ.pop('APP_ENV', None)
+
+from app import app, db
+from models import Project, User
+
+app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+app.config['TESTING'] = True
+
+passed = failed = 0
+
+
+def test(name, cond, detail=""):
+    global passed, failed
+    if cond:
+        passed += 1; print(f"  PASS: {name}")
+    else:
+        failed += 1; print(f"  FAIL: {name} - {detail}")
+
+
+CSS = open('static/css/style.css').read()
+
+
+def token(name):
+    m = re.search(rf'--{re.escape(name)}:\s*(#[0-9a-fA-F]{{6}})', CSS)
+    return m.group(1) if m else None
+
+
+def luminance(hexc):
+    rgb = [int(hexc.lstrip('#')[i:i + 2], 16) / 255 for i in (0, 2, 4)]
+    lin = [c / 12.92 if c <= 0.04045 else ((c + 0.055) / 1.055) ** 2.4 for c in rgb]
+    return 0.2126 * lin[0] + 0.7152 * lin[1] + 0.0722 * lin[2]
+
+
+def contrast(fg, bg):
+    la, lb = luminance(fg), luminance(bg)
+    hi, lo = max(la, lb), min(la, lb)
+    return (hi + 0.05) / (lo + 0.05)
+
+
+print("\n=== CSS: responsive structure ===")
+test("table-scroll utility exists",
+     re.search(r'\.table-scroll\s*\{[^}]*overflow-x:\s*auto', CSS) is not None)
+tablet = re.search(r'@media \(max-width: 1024px\)\s*\{(.*?)\n\}', CSS, re.DOTALL)
+test("tablet breakpoint exists", tablet is not None)
+tb = tablet.group(1) if tablet else ""
+test("sidebar goes off-canvas on tablet", 'translateX(-100%)' in tb)
+test("drawer state slides it back in", '.sidebar.mobile-open' in tb and 'translateX(0)' in tb)
+test("main content reclaims the sidebar margin", 'margin-left: 0' in tb)
+test("backdrop styled for the open drawer", '.sidebar-backdrop' in tb)
+
+mobile = re.search(r'@media \(max-width: 860px\)\s*\{(.*?)\n\}', CSS, re.DOTALL)
+mb = mobile.group(1) if mobile else ""
+test("mobile breakpoint exists", mobile is not None)
+test("unwrapped wide tables scroll in their own box",
+     '.proposals-table, .mini-table' in mb and 'overflow-x: auto' in mb)
+test("16px inputs prevent iOS focus zoom", 'font-size: 16px' in mb)
+# Found by the browser drive: flex children without min-width: 0 pushed the
+# topbar wider than the viewport, and the trend chart / month calendar have
+# intrinsic widths that must scroll inside their cards.
+test("topbar search can shrink below content size", 'min-width: 0' in mb)
+test("avatar name hidden on phones", '.avatar-name' in mb)
+test("keyboard hint hidden with matching specificity",
+     '.topbar-search .kbd-hint { display: none; }' in mb)
+test("trend chart scrolls in its card", '.trend-chart { overflow-x: auto' in mb)
+test("calendar keeps usable day cells and scrolls",
+     '.calendar-grid { min-width: 640px; }' in mb)
+test("admin activity filter wraps", '.activity-filter { flex-wrap: wrap; }' in mb)
+test("focus-visible ring survives the sweep", ':focus-visible' in CSS and 'outline: 2px solid' in CSS)
+test("reduced-motion preference honored", 'prefers-reduced-motion' in CSS)
+
+print("\n=== CSS: WCAG AA contrast (computed) ===")
+paper, mist = token('paper'), token('mist')
+checks = [
+    ("body text (ink-900 on paper)", token('ink-900'), paper, 4.5),
+    ("secondary text (ink-700 on paper)", token('ink-700'), paper, 4.5),
+    ("muted text (ink-500 on paper)", token('ink-500'), paper, 4.5),
+    ("muted text (ink-500 on mist)", token('ink-500'), mist, 4.5),
+    ("gold badge text on gold-bg", token('gold'), token('gold-bg'), 4.5),
+    ("red badge text on red-bg", token('red'), token('red-bg'), 4.5),
+    ("ok badge text on ok-bg", token('ok'), token('ok-bg'), 4.5),
+    ("violet badge text on violet-bg", token('violet'), token('violet-bg'), 4.5),
+    ("sidebar text on sea-900", token('sidebar-text') or '#b9d6cc', token('sea-900'), 4.5),
+]
+for name, fg, bg, minimum in checks:
+    if not (fg and bg):
+        test(f"{name}: tokens found", False, f"fg={fg} bg={bg}")
+        continue
+    r = contrast(fg, bg)
+    test(f"{name} >= {minimum}:1", r >= minimum, f"{r:.2f}")
+
+for selector in ('.footer', '.timeline .tl-meta', '.step.step-pending'):
+    block = CSS.split(selector, 1)[1][:220] if selector in CSS else ''
+    test(f"{selector} text no longer uses ink-300",
+         'var(--ink-300)' not in block and 'var(--ink-500)' in block, block[:80])
+
+print("\n=== Templates compile after the table wrapping ===")
+for name in ('base.html', 'proposals.html', 'admin.html', 'reports.html',
+             'proposal_estimate.html', 'ingest_review.html',
+             'clarification_register.html', 'calendar.html'):
+    try:
+        app.jinja_env.get_template(name)
+        test(f"{name} compiles", True)
+    except Exception as e:
+        test(f"{name} compiles", False, str(e))
+
+test("calendar grid is wrapped in a scroll container",
+     'table-scroll' in open('web_templates/calendar.html').read())
+
+for name in ('proposals.html', 'admin.html', 'reports.html',
+             'proposal_estimate.html', 'ingest_review.html',
+             'clarification_register.html'):
+    src = open(f'web_templates/{name}').read()
+    test(f"{name} wide tables are wrapped",
+         src.count('table-scroll') >= src.count('<table class="proposals-table')
+         and 'table-scroll' in src)
+
+print("\n=== Rendered pages: ARIA wiring ===")
+with app.app_context():
+    db.drop_all(); db.create_all()
+    c = app.test_client()
+    c.post('/signup', data={'username': 'ada', 'email': 'ada@corp.com',
+                            'password': 'password123', 'company_name': 'AdaCo'})
+    ada = User.query.filter_by(username='ada').first()
+    ada.email_verified = True
+    db.session.add(Project(name='ClosedNoDetails', client_name='Acme',
+                           user_id=ada.id, org_id=ada.org_id, status='lost',
+                           dollar_amount=1000.0,
+                           closed_at=datetime.now(timezone.utc).replace(tzinfo=None)))
+    db.session.commit()
+
+    html = c.get('/').data.decode()
+    test("viewport meta present", 'name="viewport"' in html)
+    test("skip link present", 'skip-link' in html)
+    test("sidebar has an id the toggle controls",
+         'id="app-sidebar"' in html and 'aria-controls="app-sidebar"' in html)
+    toggle_html = html[html.find('id="sidebar-toggle"'):][:300]
+    test("sidebar toggle exposes expanded state", 'aria-expanded' in toggle_html)
+    backdrop_html = html[html.find('class="sidebar-backdrop"'):][:120]
+    test("drawer backdrop rendered hidden",
+         'id="sidebar-backdrop"' in backdrop_html and 'hidden' in backdrop_html)
+    test("global search input is labelled",
+         'aria-label="Search projects, proposals, and documents"' in html)
+    test("chatbot input is labelled", 'aria-label="Ask the help assistant"' in html)
+    test("chatbot close is labelled", 'aria-label="Close help assistant"' in html)
+
+    html = c.get('/proposals').data.decode()
+    test("proposals table scrolls in a wrapper", 'table-scroll' in html)
+
+    html = c.get('/admin').data.decode()
+    test("admin tables scroll in wrappers", html.count('table-scroll') >= 2)
+
+    html = c.get('/reports').data.decode()
+    test("reports tables scroll in wrappers", html.count('table-scroll') >= 1)
+    test("inline close-details fields are labelled",
+         'aria-label="Close category for ClosedNoDetails"' in html
+         and 'aria-label="Competitor for ClosedNoDetails"' in html
+         and 'aria-label="Close reason for ClosedNoDetails"' in html)
+
+    r = c.get('/logout')  # POST-only; GET should not 500
+    test("auth pages unaffected (login renders)",
+         c.post('/logout').status_code in (302,) and c.get('/login').status_code == 200)
+
+print("\n" + "=" * 50)
+print(f"Results: {passed} passed, {failed} failed out of {passed + failed} tests")
+sys.exit(0 if failed == 0 else 1)

--- a/test_vertical_classifier.py
+++ b/test_vertical_classifier.py
@@ -1,0 +1,230 @@
+"""Regression tests for the LLM-based vertical classifier.
+
+document_parser.detect_vertical (keyword counting) missed RFPs that
+paraphrase — a pharma cleanroom fit-out that never says "GMP" landed in
+'general' and lost its vertical templates. proposal_agent.classify_vertical
+now asks a small, fast Claude model (CLAUDE_CLASSIFIER_MODEL) to read an
+excerpt, with the keyword scorer as the fallback on every failure path
+(no API key, API error, budget exhausted, nonsense answer) so generation
+never breaks on classification.
+
+Covers: the classifier's happy path and normalization, every fallback path,
+excerpt truncation, model selection, wiring into draft_scope_of_work and the
+generation job, and the approved-scope short-circuit that must NOT classify.
+
+Standalone runner: python test_vertical_classifier.py
+"""
+import io
+import os
+import sys
+from types import SimpleNamespace
+from unittest.mock import patch
+
+os.environ['FLASK_SECRET_KEY'] = 'test-secret-key-12345'
+os.environ.pop('APP_ENV', None)
+
+import app as appmod
+from app import app, db
+import proposal_agent
+from config.settings import CLAUDE_CLASSIFIER_MODEL
+from document_parser import detect_vertical
+from models import Project, ProjectScope, Proposal, User
+
+app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+app.config['TESTING'] = True
+
+passed = failed = 0
+
+
+def test(name, cond, detail=""):
+    global passed, failed
+    if cond:
+        passed += 1; print(f"  PASS: {name}")
+    else:
+        failed += 1; print(f"  FAIL: {name} - {detail}")
+
+
+DC_TEXT = ("RFP for a hyperscale data center: BMS and EPMS integration, "
+           "hot aisle containment, UPS and switchgear monitoring, "
+           "generator controls for the new data hall.")
+PLAIN_TEXT = "Please provide a quotation for controls services at our facility."
+
+
+class FakeCreateClient:
+    """Stands in for the metered client; records the .messages.create kwargs."""
+
+    def __init__(self, answer=None, error=None):
+        self.calls = []
+        outer = self
+
+        class _Messages:
+            def create(self, **kwargs):
+                outer.calls.append(kwargs)
+                if error is not None:
+                    raise error
+                return SimpleNamespace(
+                    content=[SimpleNamespace(type='text', text=answer)])
+
+        self.messages = _Messages()
+
+
+class FakeStreamClient:
+    """Fake for the streaming calls (draft_scope_of_work)."""
+
+    def __init__(self, text):
+        outer_text = text
+
+        class _Stream:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                return False
+
+            @property
+            def text_stream(self):
+                return iter([outer_text])
+
+        class _Messages:
+            def stream(self, **kwargs):
+                return _Stream()
+
+        self.messages = _Messages()
+
+
+print("\n=== classify_vertical: LLM path ===")
+fake = FakeCreateClient(answer='life_science')
+with patch('proposal_agent._make_client', return_value=fake):
+    result = proposal_agent.classify_vertical(PLAIN_TEXT, user_api_key='sk-test')
+test("LLM answer wins over keywords", result == 'life_science', result)
+test("classifier uses the fast model, not CLAUDE_MODEL",
+     fake.calls[0]['model'] == CLAUDE_CLASSIFIER_MODEL, fake.calls[0]['model'])
+test("classifier caps output tokens small", fake.calls[0]['max_tokens'] <= 64)
+
+fake = FakeCreateClient(answer='  "Data_Center".  ')
+with patch('proposal_agent._make_client', return_value=fake):
+    result = proposal_agent.classify_vertical(PLAIN_TEXT, user_api_key='sk-test')
+test("sloppy answers are normalized", result == 'data_center', result)
+
+huge = "controls " + ("x" * 100_000)
+fake = FakeCreateClient(answer='general')
+with patch('proposal_agent._make_client', return_value=fake):
+    proposal_agent.classify_vertical(huge, user_api_key='sk-test')
+sent = fake.calls[0]['messages'][0]['content']
+test("only an excerpt is sent to the model",
+     len(sent) <= proposal_agent.CLASSIFIER_MAX_CHARS + 200, len(sent))
+
+print("\n=== classify_vertical: fallback paths ===")
+fake = FakeCreateClient(answer='underwater_basket_weaving')
+with patch('proposal_agent._make_client', return_value=fake):
+    result = proposal_agent.classify_vertical(DC_TEXT, user_api_key='sk-test')
+test("nonsense answer falls back to keywords", result == 'data_center', result)
+
+fake = FakeCreateClient(error=RuntimeError('api down'))
+with patch('proposal_agent._make_client', return_value=fake):
+    result = proposal_agent.classify_vertical(DC_TEXT, user_api_key='sk-test')
+test("API error falls back to keywords", result == 'data_center', result)
+
+fake = FakeCreateClient(error=proposal_agent.AiBudgetExceeded('budget gone'))
+with patch('proposal_agent._make_client', return_value=fake):
+    result = proposal_agent.classify_vertical(DC_TEXT, user_api_key='sk-test')
+test("budget exhaustion falls back (main call surfaces the error)",
+     result == 'data_center', result)
+
+with patch('proposal_agent._make_client') as mc, \
+     patch('proposal_agent.ANTHROPIC_API_KEY', ''):
+    result = proposal_agent.classify_vertical(DC_TEXT)
+test("no API key -> keyword path without constructing a client",
+     result == 'data_center' and not mc.called)
+
+with patch('proposal_agent._make_client') as mc:
+    result = proposal_agent.classify_vertical('   ', user_api_key='sk-test')
+test("blank text skips the LLM call", result == 'general' and not mc.called)
+
+print("\n=== keyword fallback still behaves ===")
+test("keyword: data_center", detect_vertical(DC_TEXT) == 'data_center')
+test("keyword: life_science",
+     detect_vertical("GMP cleanroom validation IQ/OQ/PQ for aseptic pharma "
+                     "fill finish suite with sterile WFI loop") == 'life_science')
+test("keyword: food_beverage",
+     detect_vertical("HACCP and FSMA compliant food processing line with "
+                     "washdown sanitary design and USDA packaging line") == 'food_beverage')
+test("keyword: weak signal -> general", detect_vertical(PLAIN_TEXT) == 'general')
+test("keyword: empty -> general", detect_vertical('') == 'general')
+
+print("\n=== draft_scope_of_work auto-detect uses the classifier ===")
+scope_json = ('{"summary": "s", "items": [{"item": "Do the work", '
+              '"category": "general"}]}')
+with patch('proposal_agent.classify_vertical', return_value='food_beverage') as cv, \
+     patch('proposal_agent._make_client', return_value=FakeStreamClient(scope_json)):
+    result = proposal_agent.draft_scope_of_work(
+        "some rfp text", vertical="auto", user_api_key='sk-test')
+test("scope draft classifies via the LLM path",
+     cv.called and result['vertical'] == 'food_beverage'
+     and result['vertical_label'] == 'Food & Beverage / CPG',
+     str(result))
+with patch('proposal_agent.classify_vertical') as cv, \
+     patch('proposal_agent._make_client', return_value=FakeStreamClient(scope_json)):
+    result = proposal_agent.draft_scope_of_work(
+        "some rfp text", vertical="data_center", user_api_key='sk-test')
+test("explicit vertical skips classification",
+     not cv.called and result['vertical'] == 'data_center')
+
+print("\n=== generation job wiring ===")
+
+
+def fake_generate(rfp_text, **kwargs):
+    return {"proposal_markdown": "# P\n\n## Scope of Work\n\nx",
+            "action_items": [], "confidence_score": 80, "document_type": "RFP",
+            "vertical": kwargs.get("vertical") or "general",
+            "vertical_label": "General",
+            "generated_at": "2026-01-01T00:00:00+00:00"}
+
+
+with app.app_context():
+    db.drop_all(); db.create_all()
+    c = app.test_client()
+    c.post('/signup', data={'username': 'vic', 'email': 'vic@corp.com',
+                            'password': 'password123', 'company_name': 'VicCo'})
+    vic = User.query.filter_by(username='vic').first()
+    vic.email_verified = True
+    db.session.commit()
+
+    c.post('/projects/new', data={'project_name': 'ClassifyBid', 'client_name': 'Acme'})
+    proj = Project.query.filter_by(name='ClassifyBid').first()
+    c.post(f'/projects/{proj.id}/upload', data={
+        'file_type': 'rfp',
+        'documents': (io.BytesIO(b'Build a facility control system'), 'rfp.txt'),
+    }, content_type='multipart/form-data')
+
+    with patch('app.generate_proposal', side_effect=fake_generate), \
+         patch('app.classify_vertical', return_value='life_science') as cv:
+        c.post(f'/projects/{proj.id}/generate',
+               data={'vertical': 'auto', 'output_format': 'md'})
+    prop = Proposal.query.filter_by(project_id=proj.id).first()
+    test("auto generation classifies with the LLM and uses the result",
+         cv.called and prop is not None and prop.vertical == 'life_science',
+         f"called={cv.called} vertical={prop and prop.vertical}")
+
+    # An approved scope's vertical takes precedence — no classify call at all.
+    scope = ProjectScope.query.filter_by(project_id=proj.id).first()
+    if not scope:
+        scope = ProjectScope(project_id=proj.id, status='approved',
+                             vertical='data_center', vertical_label='Data Center')
+        db.session.add(scope)
+    else:
+        scope.status = 'approved'; scope.vertical = 'data_center'
+    db.session.commit()
+    with patch('app.generate_proposal', side_effect=fake_generate), \
+         patch('app.classify_vertical') as cv:
+        c.post(f'/projects/{proj.id}/generate',
+               data={'vertical': 'auto', 'output_format': 'md'})
+    latest = (Proposal.query.filter_by(project_id=proj.id)
+              .order_by(Proposal.generated_at.desc()).first())
+    test("approved scope vertical short-circuits classification",
+         not cv.called and latest.vertical == 'data_center',
+         f"called={cv.called} vertical={latest.vertical}")
+
+print("\n" + "=" * 50)
+print(f"Results: {passed} passed, {failed} failed out of {passed + failed} tests")
+sys.exit(0 if failed == 0 else 1)

--- a/web_templates/admin.html
+++ b/web_templates/admin.html
@@ -39,7 +39,8 @@
     </form>
 
     {% if pending_invitations %}
-    <table class="mini-table" style="margin-top:16px;">
+    <div class="table-scroll">
+<table class="mini-table" style="margin-top:16px;">
         <thead><tr><th>Pending invitation</th><th>Role</th><th>Invited</th><th></th></tr></thead>
         <tbody>
         {% for inv in pending_invitations %}
@@ -56,6 +57,7 @@
         {% endfor %}
         </tbody>
     </table>
+</div>
     {% endif %}
 </div>
 
@@ -124,7 +126,8 @@
 <div class="card">
     <h2>Rep Performance</h2>
     <p class="card-desc">Track each user's project pipeline, win/loss record, and proposal generation activity.</p>
-    <table class="proposals-table">
+    <div class="table-scroll">
+<table class="proposals-table">
         <thead>
             <tr>
                 <th>Rep Name</th>
@@ -186,6 +189,7 @@
             {% endfor %}
         </tbody>
     </table>
+</div>
 </div>
 
 <!-- Single sign-on -->
@@ -251,7 +255,8 @@
             </span>
         </div>
     </div>
-    <table class="mini-table">
+    <div class="table-scroll">
+<table class="mini-table">
         <thead><tr><th>User</th><th>Role</th><th>Action</th><th>Detail</th><th>Time</th></tr></thead>
         <tbody>
         {% for log in recent_activity %}
@@ -265,5 +270,6 @@
         {% endfor %}
         </tbody>
     </table>
+</div>
 </div>
 {% endblock %}

--- a/web_templates/base.html
+++ b/web_templates/base.html
@@ -11,7 +11,7 @@
 <body{% if not current_user.is_authenticated %} class="auth-page"{% endif %}>
     {% if current_user.is_authenticated %}
     <a class="skip-link" href="#main-content">Skip to main content</a>
-    <aside class="sidebar">
+    <aside class="sidebar" id="app-sidebar">
         <div class="sidebar-brand">
             <a href="{{ url_for('dashboard') }}">
                 <img src="{{ url_for('static', filename='img/pm-logo-mark.svg') }}" alt="{{ app_name }}" class="brand-logo">
@@ -108,14 +108,17 @@
         </div>
     </aside>
 
+    <div class="sidebar-backdrop" id="sidebar-backdrop" hidden></div>
+
     <div class="main-wrapper">
         <header class="topbar">
-            <button class="sidebar-toggle" id="sidebar-toggle" type="button" aria-label="Toggle sidebar">&#9776;</button>
+            <button class="sidebar-toggle" id="sidebar-toggle" type="button" aria-label="Toggle sidebar"
+                    aria-controls="app-sidebar" aria-expanded="true">&#9776;</button>
             <nav class="breadcrumb" aria-label="Breadcrumb">
                 {% block breadcrumb %}<span class="crumb-current">Workspace</span>{% endblock %}
             </nav>
             <form class="topbar-search" method="get" action="{{ url_for('search') }}">
-                <input type="text" id="global-search-input" name="q" placeholder="Search projects, proposals, documents…" value="{{ request.args.get('q', '') if request.endpoint == 'search' else '' }}" autocomplete="off">
+                <input type="text" id="global-search-input" name="q" aria-label="Search projects, proposals, and documents" placeholder="Search projects, proposals, documents…" value="{{ request.args.get('q', '') if request.endpoint == 'search' else '' }}" autocomplete="off">
                 <span class="kbd-hint"><kbd>&#8984;</kbd><kbd>K</kbd></span>
                 <button type="submit" aria-label="Search"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" width="13" height="13"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg></button>
             </form>
@@ -130,7 +133,7 @@
                 <div class="avatar-wrap">
                     <button type="button" class="avatar-chip" id="avatar-toggle" aria-haspopup="true" aria-expanded="false">
                         <span class="avatar-circle">{{ (current_user.display_name or current_user.username)[:1] | upper }}{{ ((current_user.display_name or current_user.username).split(' ')[1][:1] | upper) if ' ' in (current_user.display_name or current_user.username) else '' }}</span>
-                        <span>{{ current_user.display_name or current_user.username }}</span>
+                        <span class="avatar-name">{{ current_user.display_name or current_user.username }}</span>
                         <span class="avatar-caret">&#9662;</span>
                     </button>
                     <div class="avatar-menu" id="avatar-menu">
@@ -187,13 +190,13 @@
     <div class="chatbot-panel" id="chatbot-panel">
         <div class="chatbot-header">
             <h3>Help Assistant</h3>
-            <button class="chatbot-close" id="chatbot-close" type="button">&times;</button>
+            <button class="chatbot-close" id="chatbot-close" type="button" aria-label="Close help assistant">&times;</button>
         </div>
         <div class="chatbot-messages" id="chatbot-messages">
             <div class="chat-msg chat-msg-bot">Hi! I can help you with using {{ app_name }}. Ask me about generating proposals, uploading files, cost estimation, version history, and more.</div>
         </div>
         <div class="chatbot-input">
-            <input type="text" id="chatbot-input" placeholder="Type a question..." autocomplete="off">
+            <input type="text" id="chatbot-input" aria-label="Ask the help assistant" placeholder="Type a question..." autocomplete="off">
             <button type="button" id="chatbot-send">Send</button>
         </div>
     </div>
@@ -276,15 +279,47 @@
         };
     })();
     (function(){
-        // Sidebar toggle
+        // Sidebar toggle. Desktop: collapse to the icon rail. Tablet/mobile
+        // (≤1024px): the sidebar is an off-canvas drawer — the same button
+        // opens/closes it over a backdrop instead.
         var toggle = document.getElementById("sidebar-toggle");
         var sidebar = document.querySelector(".sidebar");
         var wrapper = document.querySelector(".main-wrapper");
+        var backdrop = document.getElementById("sidebar-backdrop");
+        var drawerMode = window.matchMedia("(max-width: 1024px)");
+
+        function setExpanded(){
+            if (!toggle) return;
+            var open = drawerMode.matches
+                ? sidebar.classList.contains("mobile-open")
+                : !sidebar.classList.contains("collapsed");
+            toggle.setAttribute("aria-expanded", open ? "true" : "false");
+        }
+        function closeDrawer(){
+            sidebar.classList.remove("mobile-open");
+            if (backdrop) backdrop.hidden = true;
+            setExpanded();
+        }
         if (toggle && sidebar) {
             toggle.addEventListener("click", function() {
-                sidebar.classList.toggle("collapsed");
-                wrapper.classList.toggle("sidebar-collapsed");
+                if (drawerMode.matches) {
+                    var open = sidebar.classList.toggle("mobile-open");
+                    if (backdrop) backdrop.hidden = !open;
+                } else {
+                    sidebar.classList.toggle("collapsed");
+                    wrapper.classList.toggle("sidebar-collapsed");
+                }
+                setExpanded();
             });
+            if (backdrop) backdrop.addEventListener("click", closeDrawer);
+            document.addEventListener("keydown", function(e){
+                if (e.key === "Escape" && drawerMode.matches
+                    && sidebar.classList.contains("mobile-open")) closeDrawer();
+            });
+            if (drawerMode.addEventListener) {
+                drawerMode.addEventListener("change", function(){ closeDrawer(); });
+            }
+            setExpanded();
         }
 
         // Avatar dropdown

--- a/web_templates/calendar.html
+++ b/web_templates/calendar.html
@@ -56,6 +56,7 @@
         </div>
     </div>
 
+    <div class="table-scroll">
     <table class="calendar-grid">
         <thead>
             <tr>
@@ -96,5 +97,6 @@
             {% endfor %}
         </tbody>
     </table>
+    </div>
 </div>
 {% endblock %}

--- a/web_templates/clarification_register.html
+++ b/web_templates/clarification_register.html
@@ -153,7 +153,8 @@
 <!-- Items List -->
 {% if items %}
 <div class="card">
-    <table class="proposals-table">
+    <div class="table-scroll">
+<table class="proposals-table">
         <thead>
             <tr>
                 <th>ID</th>
@@ -252,6 +253,7 @@
         {% endfor %}
         </tbody>
     </table>
+</div>
 </div>
 {% else %}
 <div class="card empty-state">

--- a/web_templates/ingest_review.html
+++ b/web_templates/ingest_review.html
@@ -12,10 +12,11 @@
 <form method="post" action="{{ url_for('ingest_rates_confirm') }}">
     <input type="hidden" name="target_type" value="{{ target }}">
     <div class="card">
-        <table class="proposals-table">
+        <div class="table-scroll">
+<table class="proposals-table">
             <thead>
                 <tr>
-                    <th style="width:40px;"><input type="checkbox" id="check-all" checked></th>
+                    <th style="width:40px;"><input type="checkbox" id="check-all" checked aria-label="Select all rows"></th>
                     {% for key, label in meta.cols %}<th>{{ label }}</th>{% endfor %}
                 </tr>
             </thead>
@@ -24,15 +25,17 @@
                 <tr>
                     <td>
                         <input type="hidden" name="row_marker" value="{{ loop.index0 }}">
-                        <input type="checkbox" name="include" value="{{ loop.index0 }}" checked class="row-check">
+                        <input type="checkbox" name="include" value="{{ loop.index0 }}" checked class="row-check" aria-label="Include row {{ loop.index }}">
                     </td>
+                    {% set row_num = loop.index %}
                     {% for key, label in meta.cols %}
-                    <td><input type="text" name="{{ key }}" value="{{ row.get(key, '') }}" style="width:100%;"></td>
+                    <td><input type="text" name="{{ key }}" value="{{ row.get(key, '') }}" style="width:100%;" aria-label="{{ label }} (row {{ row_num }})"></td>
                     {% endfor %}
                 </tr>
                 {% endfor %}
             </tbody>
         </table>
+</div>
         <div class="form-actions">
             <button type="submit" class="btn btn-primary">Import {{ meta.label }}</button>
             <a href="{{ url_for('posture') }}{{ meta.anchor }}" class="btn btn-secondary">Cancel</a>

--- a/web_templates/job_status.html
+++ b/web_templates/job_status.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 {% block title %}Working… — {{ app_name }}{% endblock %}
-{% block breadcrumb %}<span class="crumb-current">Generating proposal</span>{% endblock %}
+{% block breadcrumb %}<span class="crumb-current">{{ kind_label or "Working" }}</span>{% endblock %}
 
 {% block content %}
 <div class="page-narrow">
@@ -72,7 +72,7 @@
           stopElapsed();
           if (cancelForm) cancelForm.style.display = "none";
           titleEl.textContent = "Done!";
-          phaseEl.textContent = "Redirecting to your proposal…";
+          phaseEl.textContent = "Redirecting…";
           window.location.href = d.redirect;
           return;
         }

--- a/web_templates/proposal_estimate.html
+++ b/web_templates/proposal_estimate.html
@@ -22,7 +22,8 @@
 
 <form method="post" action="{{ url_for('save_proposal_estimate', proposal_id=proposal.id) }}" id="estimate-form">
     <div class="card">
-        <table class="proposals-table" id="estimate-grid">
+        <div class="table-scroll">
+<table class="proposals-table" id="estimate-grid">
             <thead>
                 <tr>
                     <th style="width:120px;">Type</th>
@@ -56,6 +57,7 @@
                 {% endfor %}
             </tbody>
         </table>
+</div>
         <button type="button" class="btn btn-small btn-secondary" id="add-row">+ Add line</button>
 
         <div class="estimate-summary">

--- a/web_templates/proposals.html
+++ b/web_templates/proposals.html
@@ -108,6 +108,7 @@
 {% endif %}
 {% else %}
 {% if rows %}
+<div class="table-scroll">
 <table class="proposals-table">
     <thead>
         <tr>
@@ -191,6 +192,7 @@
         {% endfor %}
     </tbody>
 </table>
+</div>
 {% set pg_args = {'filter': active_filter, 'q': q, 'status': f_status,
                   'vertical': f_vertical, 'sort': sort, 'dir': direction,
                   'view': view} %}

--- a/web_templates/reports.html
+++ b/web_templates/reports.html
@@ -71,7 +71,8 @@
 <div class="card">
     <h2>Performance by Vertical</h2>
     {% if vertical_stats %}
-    <table class="proposals-table">
+    <div class="table-scroll">
+<table class="proposals-table">
         <thead>
             <tr>
                 <th>Vertical</th>
@@ -102,6 +103,7 @@
             {% endfor %}
         </tbody>
     </table>
+</div>
     {% else %}
     <p class="empty-state">No projects yet.</p>
     {% endif %}
@@ -165,7 +167,8 @@
 {% if top_competitors %}
 <div class="card">
     <h2>Top Competitors</h2>
-    <table class="proposals-table">
+    <div class="table-scroll">
+<table class="proposals-table">
         <thead>
             <tr>
                 <th>Competitor</th>
@@ -193,6 +196,7 @@
         </tbody>
     </table>
 </div>
+</div>
 {% endif %}
 
 <!-- Missing details call-to-action -->
@@ -200,7 +204,8 @@
 <div class="card card-highlight">
     <h2>Fill in Missing Close Details</h2>
     <p class="card-desc">These closed projects are missing win/loss reasons or competitor info. Add context to strengthen reports.</p>
-    <table class="proposals-table">
+    <div class="table-scroll">
+<table class="proposals-table">
         <thead>
             <tr>
                 <th>Project</th>
@@ -217,14 +222,14 @@
                 <td>{{ "${:,.0f}".format(p.dollar_amount) if p.dollar_amount else '—' }}</td>
                 <td>
                     <form method="post" action="{{ url_for('update_close_details', project_id=p.id) }}" class="close-details-inline-form">
-                        <select name="close_category" class="status-select">
+                        <select name="close_category" class="status-select" aria-label="Close category for {{ p.name }}">
                             <option value="">Category…</option>
                             {% for key, label in category_labels.items() %}
                             <option value="{{ key }}" {{ 'selected' if p.close_category == key }}>{{ label }}</option>
                             {% endfor %}
                         </select>
-                        <input type="text" name="competitor_name" placeholder="Competitor" value="{{ p.competitor_name }}" class="inline-text">
-                        <input type="text" name="close_reason" placeholder="Reason / notes" value="{{ p.close_reason }}" class="inline-text inline-text-wide">
+                        <input type="text" name="competitor_name" placeholder="Competitor" value="{{ p.competitor_name }}" class="inline-text" aria-label="Competitor for {{ p.name }}">
+                        <input type="text" name="close_reason" placeholder="Reason / notes" value="{{ p.close_reason }}" class="inline-text inline-text-wide" aria-label="Close reason for {{ p.name }}">
                         <button type="submit" class="btn btn-small btn-primary">Save</button>
                     </form>
                 </td>
@@ -232,6 +237,7 @@
             {% endfor %}
         </tbody>
     </table>
+</div>
 </div>
 {% endif %}
 {% endblock %}


### PR DESCRIPTION
Addendum impact analysis, targeted section regeneration, and the posture
"AI import & review" flows (rates + standards) were the last AI calls still
running in the request path - minutes-long Claude calls holding a gunicorn
worker and risking load-balancer timeouts. All four now follow the
established job pattern: the route validates cheaply and enqueues, the user
lands on the progress page (poll + cancel), and the handler does the slow
work.

Background jobs
- analyze_addendum: parses the addendum + original RFP (now with ocr=True -
  scanned addenda work, and OCR is allowed inside jobs), runs the AI
  comparison, files ClarificationItems, and redirects to the register.
- regenerate_section: AI-rewrites one section, saves the new version, and
  re-renders the md/docx artifacts (mirrored to object storage).
- ingest_rates / ingest_standards: parse the upload (ocr=True for PDFs),
  AI-extract rows/blocks into job.result, and redirect to a new
  GET /posture/ingest-review/<job_id> screen that renders the review table
  from the finished job (owner-only; non-ingest kinds 404). The confirm
  POSTs are unchanged.
- The progress page breadcrumb now labels the job kind instead of always
  saying "Generating proposal".

Hardening picked up along the way
- All four routes gain the platform-AI verified-email gate; the ingest
  flows previously had none.
- The addendum route now requires the selected document to belong to the
  project - any authenticated user could previously feed another tenant's
  document id into their analysis.
- Section regeneration fails fast (flash, no job, no tokens) when the
  heading isn't found in the proposal; previously a typo spent the full AI
  call and silently saved an unchanged version.

Worker-context fix (affects ALL job kinds)
- Job handlers finish by building their redirect with url_for(), but the
  worker threads ran them in a bare app_context and no SERVER_NAME is
  configured - in production every job did all its work, committed, then
  died on the final url_for and reported "failed" to the user. Workers now
  run jobs in a request context (jobs._job_context). Tests never caught
  this because TESTING runs jobs inline inside the enqueuing request.

New suite test_ai_jobs.py (39 checks): end-to-end runs of all four flows
with the AI mocked, OCR flag propagation, register/version/artifact
contents, the email gate, cross-project doc rejection, fail-fast guards,
review-screen access control, failure surfacing, and a worker-context
url_for regression probe. Existing 11 suites stay green (545 checks total).